### PR TITLE
[Feature] Improve SuperDebug layout, add label and promise options

### DIFF
--- a/src/lib/client/SuperDebug.svelte
+++ b/src/lib/client/SuperDebug.svelte
@@ -6,8 +6,8 @@
   export let data: any;
   export let stringTruncate = 120;
   export let ref: HTMLPreElement | undefined = undefined;
-  //export let wrapText = true;
-  //export let expanded = false;
+  export let label = "";
+  export let promise = false;
 
   function syntaxHighlight(json: any) {
     json = JSON.stringify(
@@ -72,48 +72,82 @@
       }
     );
   }
+
+  async function promiseSyntaxHighlight(json: any) {
+    json = await json
+    return syntaxHighlight(json)
+  }
 </script>
 
 {#if display}
   <div class="super-debug">
     {#if status}
-      <div
-        class:info={$page.status < 200}
-        class:success={$page.status >= 200 && $page.status < 300}
-        class:redirect={$page.status >= 300 && $page.status < 400}
-        class:error={$page.status >= 400}
-        class="super-debug--status"
-      >
-        <div>{$page.status}</div>
+      <div class="super-debug--status {label === "" ? 'absolute inset-x-0 top-0' : ''}">
+        <div class="super-debug--label">{label}</div>
+        <div
+          class:info={$page.status < 200}
+          class:success={$page.status >= 200 && $page.status < 300}
+          class:redirect={$page.status >= 300 && $page.status < 400}
+          class:error={$page.status >= 400}
+        >
+          {$page.status}
+        </div>
       </div>
     {/if}
-    <pre class="super-debug--pre" bind:this={ref}><code
+    <pre class="super-debug--pre {label === "" ? 'pt-4' : 'pt-0'}" bind:this={ref}><code
         class="super-debug--code"
         ><slot
-          >{#if data}{@html syntaxHighlight(data)}{/if}</slot
+          >{#if promise}{#await promiseSyntaxHighlight(data) }<div>Loading data</div>{:then result}{@html result}{/await}{:else}{@html syntaxHighlight(data)}{/if}</slot
         ></code
       ></pre>
   </div>
 {/if}
 
 <style>
-  .super-debug .super-debug--status {
-    display: flex;
-    padding-right: 16px;
-    justify-content: right;
-    position: relative;
-    height: 0;
-    z-index: 1;
-    text-shadow: 0px 1px 2px rgba(255, 255, 255, 0.25);
+  .absolute {
+    position: absolute;
   }
 
-  .super-debug .super-debug--status > div {
-    padding-top: 10px;
+  .top-0 {
+    top: 0;
+  }
+
+  .inset-x-0 {
+    left: 0px;
+    right: 0px;
+  }
+
+  .pt-0 {
+    padding-top: 0px;
+  }
+
+  .pt-4 {
+    padding-top: 1em;
+  }
+
+  .super-debug {
+    position: relative;
+    background-color: #222;
+    border-radius: 0.5rem;
+    overflow: hidden;
+  }
+
+  .super-debug .super-debug--status {
+    display: flex;
+    padding: 1em;
+    justify-content: space-between;
+  }
+
+  .super-debug--label {
+    color: white;
   }
 
   .super-debug pre {
     color: #999;
     background-color: #222;
+    margin-bottom: 0px;
+    /** Sakura is doing 0.9em, turn font-size back to 1em **/
+    font-size: 1em;
   }
 
   .info {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -35,7 +35,7 @@
 
 <SuperDebug data={{ $form, $staticform }} />
 
-<a href="/test">Test page</a> | <a href="/crud">CRUD</a>
+<a href="/test">Test page</a> | <a href="/crud">CRUD</a> | <a href="/super-debug">SuperDebug</a>
 
 {#if $message}
   <h4 class:error={$page.status >= 400} class="message">{$message}</h4>

--- a/src/routes/super-debug/+page.server.ts
+++ b/src/routes/super-debug/+page.server.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { superValidate } from '$lib/server';
+import { error, fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+
+import { users, userId, userSchema } from '$lib/users';
+
+const schema = z.object({
+    full_name: z.string().min(1, "Full Name is required."),
+    email: z.string().min(1, "Email is required.").email("Email is invalid."),
+    phone_number: z.string().min(1, "Phone number is required."),
+});
+
+export const load = (async ({ request }) => {
+    const form = await superValidate(request, schema);
+
+    return { form };
+}) satisfies PageServerLoad;
+
+export const actions = {
+    default: async ({ request }) => {
+        const formData = await request.formData();
+        const form = await superValidate(formData, schema);
+        if (!form.valid) return fail(400, { form });
+
+        return { form };
+    }
+} satisfies Actions;

--- a/src/routes/super-debug/+page.svelte
+++ b/src/routes/super-debug/+page.svelte
@@ -1,0 +1,100 @@
+<script>
+    import { page } from '$app/stores';
+    import { superForm } from '$lib/client';
+    import SuperDebug from '$lib/client/SuperDebug.svelte';
+    import { onMount } from 'svelte';
+
+    export let data;
+    /**
+     * @type {any}
+     */
+    let someUnknownData;
+    const emptyObject = {};
+    const promiseNeverCameTrue = new Promise((resolve, reject) => {
+        setTimeout(() => resolve({}), 5000)
+    })
+    /**
+     * @type {() => any}
+     */
+    let promiseProduct = () => {}
+    const someObject = {
+        full_name: "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff Sr."
+    }
+
+    const { form } = superForm(data.form);
+
+    $form.full_name = "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff Sr."
+
+    onMount(async () => {
+        // Put fetch inside onMount so svelte would stop gawking at us.
+        promiseProduct = async () => {
+            const response = await fetch('https://dummyjson.com/products/1')
+            const body = await response.json()
+            return body
+        }
+    })
+</script>
+
+<main class="space-y-4">
+    <section>
+        <h4>Super Debug with label</h4>
+        <p>Label is useful when using multiple instance of SuperDebug.</p>
+        <SuperDebug label="Sample User" data={$form} />
+    </section>
+    <section>
+        <h4>Super Debug without label</h4>
+        <p>This is SuperDebug's classic layout. Make sure we don't have weird spaces when there is no label.</p>
+        <SuperDebug data={$form} />
+    </section>
+    <section>
+        <h4>Super Debug with label and undefined data</h4>
+        <p>Do not hide output from <code>syntaxHighlight</code> even when the result is undefined. In JavaScript it is a crucial piece of information.</p>
+        <SuperDebug label="Data not ready" data={someUnknownData} />
+    </section>
+    <section>
+        <h4>Super Debug without label and undefined data</h4>
+        <p>There are cases when the data is not readily available on page load. Make sure SuperDebug layout does not break on itself.</p>
+        <SuperDebug data={someUnknownData} />
+    </section>
+    <section>
+        <h4>Super Debug with empty object</h4>
+        <SuperDebug data={emptyObject} />
+    </section>
+    <section class="space-y-4">
+        <h4>Super Debug promise support</h4>
+        <p>Fancy way of loading things for fancy people. Try reloading the page to see it in action. Right now when waiting for promise a message that says "Loading data" appears. Having a named slot for customization is nice but it is trivial.</p>
+        <pre><code>{@html `let promiseNeverCameTrue = new Promise((resolve, reject) => {
+    setTimeout(() => resolve({}), 5000)
+})`}
+{@html "&lt;SuperDebug promise={true} data={promiseNeverCameTrue} /&gt;"}</code></pre>
+        <SuperDebug promise={true} data={promiseNeverCameTrue} />
+        <pre><code>{@html `let promiseProduct = async () => {
+    const response = await fetch('https://dummyjson.com/products/1')
+    const body = await response.json()
+    return body
+}`}
+{@html `&lt;SuperDebug label="Dummyjson product" promise={true} data={promiseProduct()} /&gt;`}</code></pre>
+        <SuperDebug label="Dummyjson product" promise={true} data={promiseProduct()} />
+    </section>
+    <section class="space-y-4">
+        <h4>Super Debug using promise on non-promise related data</h4>
+        <p>To see this in action, slightly scroll above near Dummyjson product and hit refresh.</p>
+        <ul style="list-style-type: none;">
+            <li>ChadDev: <b>No one can stop me from enabling promise because I can't read.</b></li>
+            <li>SuperForm: Hey, that's illegal!</li>
+            <li>ChadDev: It works!</li>
+        </ul>
+        <SuperDebug label="Promisify $form" promise={true} data={someObject} />
+    </section>
+    <section>
+        <h4>Super Debug displaying $page data</h4>
+        <p>Svelte's <code>$page</code> data in all its glory.</p>
+        <SuperDebug label="$page data" data={$page} />
+    </section>
+</main>
+
+<style>
+    :global(.space-y-4 > * + *) {
+        margin-top: 1rem;
+    }
+</style>


### PR DESCRIPTION
## What's changed

- Previously SuperDebug only shows html output if `data` evaluates to `true`, now there is no checking and will spit out `undefined` if data is `undefined`. In JavaScript knowing whether your data is `undefined` is crucial.
- Fix SuperDebug layout in cases where `data` is `undefined` or not yet ready, i.e. in cases where loading data async and it takes a while to load.
- New `label` prop, useful when using multiple instances of SuperDebug on a page.
- New `promise` prop, useful when debugging data coming from a `fetch` or any `promise` functions that may take a while to load. It uses svelte's `await` block to display a message and let users know the data is still loading.
- New `super-debug` page route to document all possible use cases of SuperDebug with the proposed changes and see it in action.

I would add documentation on readme if this looks good to you @ciscoheat .