### PR TITLE
Use `readonly` to make stores readonly

### DIFF
--- a/src/lib/client/index.ts
+++ b/src/lib/client/index.ts
@@ -36,7 +36,7 @@ import {
   traversePathAsync
 } from '../entity';
 import { fieldProxy } from './proxies';
-import { clone } from '../utils';
+import { clone, readonly } from '../utils';
 
 enum FetchStatus {
   Idle = 0,
@@ -589,17 +589,17 @@ export function superForm<
     errors: Errors,
     message: Message,
     constraints: Constraints,
-    meta: derived(Meta, ($m) => $m),
+    meta: readonly(Meta),
 
     fields: Fields,
 
-    tainted: derived(Tainted, ($t) => $t),
-    valid: derived(Valid, ($s) => $s),
-    empty: derived(Empty, ($e) => $e),
+    tainted: readonly(Tainted),
+    valid: readonly(Valid),
+    empty: readonly(Empty),
 
-    submitting: derived(Submitting, ($s) => $s),
-    delayed: derived(Delayed, ($d) => $d),
-    timeout: derived(Timeout, ($t) => $t),
+    submitting: readonly(Submitting),
+    delayed: readonly(Delayed),
+    timeout: readonly(Timeout),
 
     enhance: (el: HTMLFormElement) =>
       formEnhance(

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -17,7 +17,7 @@ export function clone<T>(data: T): T {
  * @param store - store to make readonly
  */
 export function readonly<T>(store: Readable<T>): Readable<T> {
-	return {
-		subscribe: store.subscribe.bind(store)
-	};
+  return {
+    subscribe: store.subscribe.bind(store)
+  };
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,8 +1,23 @@
 import { parse, stringify } from 'devalue';
+import type { Readable } from 'svelte/store';
 
 export function clone<T>(data: T): T {
   if ('structuredClone' in globalThis) {
     return structuredClone(data);
   }
   return parse(stringify(data));
+}
+
+/**
+ * Takes a store and returns a new one derived from the old one that is readable.
+ *
+ * @see https://github.com/sveltejs/svelte/blob/a2170f5bd5312ed6a63cc1a465826705dc295cd9/src/runtime/store/index.ts#L214-L223
+ * @todo use svelte's `readonly` function once peer dependency >= 3.56.0
+ *
+ * @param store - store to make readonly
+ */
+export function readonly<T>(store: Readable<T>): Readable<T> {
+	return {
+		subscribe: store.subscribe.bind(store)
+	};
 }


### PR DESCRIPTION
Copied `readonly` helper from svelte until the svelte version in peerDependencies is >= 3.56.0