### PR TITLE
use function for capture/restore instead of arrow function

### DIFF
--- a/src/lib/client/index.ts
+++ b/src/lib/client/index.ts
@@ -744,20 +744,22 @@ export function superForm<
 
     options,
 
-    capture: () => ({
-      valid: get(Valid),
-      errors: get(Errors),
-      data: get(Form),
-      empty: get(Empty),
-      constraints: get(Constraints),
-      message: get(Message),
-      id: formId,
-      meta: get(Meta),
-      tainted: get(Tainted)
-    }),
+    capture: function () {
+      return {
+        valid: get(Valid),
+        errors: get(Errors),
+        data: get(Form),
+        empty: get(Empty),
+        constraints: get(Constraints),
+        message: get(Message),
+        id: formId,
+        meta: get(Meta),
+        tainted: get(Tainted)
+      };
+    },
 
-    restore: (snapshot: SuperFormSnapshot<T2, M>) => {
-      rebind(snapshot, snapshot.tainted ?? true);
+    restore: function (snapshot: SuperFormSnapshot<T2, M>) {
+      return rebind(snapshot, snapshot.tainted ?? true);
     },
 
     validate: (path, opts) => {

--- a/src/routes/snapshot/+page.svelte
+++ b/src/routes/snapshot/+page.svelte
@@ -6,6 +6,17 @@
 
   export let data: PageData;
 
+  export const snapshot: Snapshot = {
+    capture: () => {
+      console.log('Capture', $page);
+      return capture();
+    },
+    restore: (value) => {
+      console.log('Restore', value, $page);
+      restore(value);
+    }
+  };
+
   const {
     form,
     errors,
@@ -22,17 +33,6 @@
       console.log($page.status);
     }
   });
-
-  export const snapshot: Snapshot = {
-    capture: () => {
-      console.log('Capture', $page);
-      return capture();
-    },
-    restore: (value) => {
-      console.log('Restore', value, $page);
-      restore(value);
-    }
-  };
 </script>
 
 <SuperDebug data={{ $form, capture: capture() }} />


### PR DESCRIPTION
I would like to write the export statement for snapshot together with other export statements (e.g. export let data).
Therefore, I suggest that the capture/restore function be defined as a normal function, not as an arrow function.
