### PR TITLE
[Feature] Custom behaviour on tainted message

### DIFF
--- a/src/lib/client/index.ts
+++ b/src/lib/client/index.ts
@@ -781,8 +781,13 @@ export function superForm<
 
   if (browser) {
     let forceRedirection = false;
-    beforeNavigate(async ({ cancel, to, willUnload }) => {
-      if (options.taintedMessage && !get(Submitting) && !forceRedirection && !willUnload) {
+    beforeNavigate(async ({ cancel, to, type }) => {
+      if (type === 'leave') {
+        // Does not display any dialog on page refresh and let the default browser behaviour
+        cancel();
+        return;
+      }
+      if (options.taintedMessage && !get(Submitting) && !forceRedirection) {
         const taintStatus = Tainted_data();
         const { taintedMessage } = options;
         let confirmFunction = (typeof taintedMessage === 'function')

--- a/src/lib/client/index.ts
+++ b/src/lib/client/index.ts
@@ -782,20 +782,19 @@ export function superForm<
   if (browser) {
     let forceRedirection = false;
     beforeNavigate(async ({ cancel, to, type }) => {
-      if (type === 'leave') {
-        // Does not display any dialog on page refresh and let the default browser behaviour
-        cancel();
-        return;
-      }
       if (options.taintedMessage && !get(Submitting) && !forceRedirection) {
         const taintStatus = Tainted_data();
         const { taintedMessage } = options;
-        let confirmFunction = (typeof taintedMessage === 'function')
-          ? taintedMessage
-          : () => Promise.resolve(window.confirm(taintedMessage));
         if (taintStatus && Tainted_isTainted(taintStatus)) {
           // As beforeNavigate does not support Promise, we cancel the redirection until the promise resolve
           cancel();
+          if (type === 'leave') {
+            // Does not display any dialog on page refresh or closing tab and let the default browser behaviour
+            return;
+          }
+          let confirmFunction = (typeof taintedMessage === 'function')
+            ? taintedMessage
+            : () => Promise.resolve(window.confirm(taintedMessage));
           // confirmFunction : 
           // - rejected => shouldRedirect = false
           // - resolved with false => shouldRedirect = false

--- a/src/routes/tainted/+page.svelte
+++ b/src/routes/tainted/+page.svelte
@@ -33,7 +33,8 @@
 <SuperDebug data={{ $tainted }} />
 
 <a href="/tainted/multiple-tainted">Multiple tainted &gt;</a> |
-<a href="/tainted/programmatically">Programmatically &gt;</a>
+<a href="/tainted/programmatically">Programmatically &gt;</a> |
+<a href="/tainted/custom-tainted-function">Custom tainted function &gt;</a>
 
 <h2>Tainted modification test</h2>
 

--- a/src/routes/tainted/custom-tainted-function/+page.server.ts
+++ b/src/routes/tainted/custom-tainted-function/+page.server.ts
@@ -1,0 +1,19 @@
+import type { Actions, PageServerLoad } from './$types';
+import { superValidate } from '$lib/server';
+import { schema } from './schemas';
+import { fail } from '@sveltejs/kit';
+
+export const load = (async (event) => {
+  const form = await superValidate(event, schema);
+  return { form };
+}) satisfies PageServerLoad;
+
+export const actions = {
+  default: async (event) => {
+    const formData = await event.request.formData();
+    const form = await superValidate(formData, schema);
+    console.log('POST', form);
+
+    return form.valid ? { form } : fail(400, { form });
+  }
+} satisfies Actions;

--- a/src/routes/tainted/custom-tainted-function/+page.svelte
+++ b/src/routes/tainted/custom-tainted-function/+page.svelte
@@ -4,7 +4,7 @@
   import SuperDebug from '$lib/client/SuperDebug.svelte';
   import type { PageData } from './$types';
   import { page } from '$app/stores';
-  import { afterNavigate } from '$app/navigation';
+  import { afterNavigate, goto } from '$app/navigation';
 
   export let data: PageData;
 
@@ -17,12 +17,12 @@
       return new Promise((resolve, reject) => {
         dialog.addEventListener('close', () => {
           // to discard redirection you can or reject the promise or resolve(false)
-          if(dialog.returnValue) {
+          if(dialog.returnValue === 'ok') {
             resolve(true);
           } else {
             reject();  // Could also be resolve(false)
           }
-        }, true)
+        }, {once: true});
       })
     }
   });
@@ -61,12 +61,14 @@
   <p>Do you want to leave this page? Changes you made may not be saved.</p>
   <div class="action-button">
     <button on:click={() => dialog.close('ok')}>Leave</button>
-    <button on:click={() => dialog.close()}>Stay</button>
+    <button on:click={() => dialog.close('ko')}>Stay</button>
   </div>
 </dialog>
 
 <a href="?">Use tick</a> |
-<a href="?timeout">Use timeout</a>
+<a href="?timeout">Use timeout</a> |
+<a href="https://github.com/ciscoheat/sveltekit-superforms" rel="noreferrer">External link</a> |
+<a href="/" on:click|preventDefault={() => goto('/')}>Programmatic link</a>
 
 <h3>Triple Set via onMount</h3>
 

--- a/src/routes/tainted/custom-tainted-function/+page.svelte
+++ b/src/routes/tainted/custom-tainted-function/+page.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import { tick } from 'svelte';
+  import { superForm } from '$lib/client';
+  import SuperDebug from '$lib/client/SuperDebug.svelte';
+  import type { PageData } from './$types';
+  import { page } from '$app/stores';
+  import { afterNavigate } from '$app/navigation';
+
+  export let data: PageData;
+
+  let message = '';
+  let dialog: HTMLDialogElement;
+
+  const { form, tainted, enhance } = superForm(data.form, {
+    taintedMessage: () => {
+      dialog.showModal();
+      return new Promise((resolve, reject) => {
+        dialog.addEventListener('close', () => {
+          // to discard redirection you can or reject the promise or resolve(false)
+          if(dialog.returnValue) {
+            resolve(true);
+          } else {
+            reject();  // Could also be resolve(false)
+          }
+        }, true)
+      })
+    }
+  });
+
+  function untaint() {
+    if ($tainted) {
+      $tainted.name = undefined;
+      $tainted.city = false;
+      delete $tainted.age;
+    }
+  }
+
+  async function resetTainted() {
+    if ($page.url.searchParams.has('timeout')) {
+      setTimeout(untaint);
+      message = 'timeout';
+    } else {
+      await tick();
+      await tick();
+      untaint();
+      message = 'tick';
+    }
+  }
+
+  afterNavigate((nav) => {
+    console.log(nav);
+    $form.name = 'Fred';
+    $form.city = 'Berlin';
+    $form.age = 28;
+
+    resetTainted();
+  });
+</script>
+
+<dialog bind:this={dialog}>
+  <p>Do you want to leave this page? Changes you made may not be saved.</p>
+  <div class="action-button">
+    <button on:click={() => dialog.close('ok')}>Leave</button>
+    <button on:click={() => dialog.close()}>Stay</button>
+  </div>
+</dialog>
+
+<a href="?">Use tick</a> |
+<a href="?timeout">Use timeout</a>
+
+<h3>Triple Set via onMount</h3>
+
+<h4>{message}</h4>
+
+<form method="POST" use:enhance>
+  <div>
+    Name:
+    <input type="text" name="name" bind:value={$form.name} />
+  </div>
+
+  <div>
+    city:
+    <input type="text" name="city" bind:value={$form.city} />
+  </div>
+
+  <div>
+    Age:
+    <input type="number" name="age" bind:value={$form.age} />
+  </div>
+
+  <div>
+    <button type="submit">Submit</button>
+  </div>
+</form>
+
+<h4>form</h4>
+<SuperDebug data={$form} />
+<h4>tainted</h4>
+<SuperDebug data={$tainted} />
+
+<style>
+  .action-button {
+    display: flex;
+    justify-content: space-around;
+  }
+</style>

--- a/src/routes/tainted/custom-tainted-function/schemas.ts
+++ b/src/routes/tainted/custom-tainted-function/schemas.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const schema = z.object({
+  name: z.string(),
+  city: z.string(),
+  age: z.number().min(1)
+});


### PR DESCRIPTION
Currently `taintedMessage` only support string message. 
This pull request extends `taintedMessage` to be able to pass a function returning a `Promise<boolean>`.

This will allow usage of any  UI library to implement this modal dialog.

## Exemple of usage
```html
<script lang="ts">
  let dialog: HTMLDialogElement;

  const { form, tainted, enhance } = superForm(data.form, {
    taintedMessage: () => {
      dialog.showModal();
      return new Promise((resolve, reject) => {
        dialog.addEventListener('close', () => {
          // to discard redirection you can or reject the promise or resolve(false)
          resolve(dialog.returnValue === 'leave');
        }, {once: true})
      })
    }
  });
</script>

<!-- define a simple HTML5 dialog -->
<dialog bind:this={dialog}>
  <p>Do you want to leave this page? Changes you made may not be saved.</p>
  <div class="action-button">
    <button on:click={() => dialog.close('leave')}>Leave</button>
    <button on:click={() => dialog.close('stay')}>Stay</button>
  </div>
</dialog>
```