### PR TITLE
fix: Fixes the `typesVersions` map to fix incorrect auto-import paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "typesVersions": {
     ">4.0": {
-      "index": [
+      "index.d.ts": [
         "./dist/index.d.ts"
       ],
       "server": [


### PR DESCRIPTION
Hello! I'm making my way around as many Svelte packages as I can to fix this annoying bug. 😄 

## The Issue: 
Packages that are auto-imported will always get `/index` appended to the end of their import paths, which in most cases, won't be a valid path and will lead to runtime errors if left alone. 

Here's a quick example if you've never experienced this before:
![img](https://i.imgur.com/6wERuiy.gif)
(this demo is using MeltUI, but the issue also applies to this package as well)

This has become a _very_ common issue across Svelte packages because SvelteKit's ["Packaging"](https://kit.svelte.dev/docs/packaging#typescript) documentation used to recommend (which has now been [patched and corrected](https://github.com/sveltejs/kit/pull/10180)) to add `index`, rather than `index.d.ts`, to the `typesVersions` map. This little typo has lead to a whole lot of packages having the same problem.

We've [experienced this issue](https://github.com/skeletonlabs/skeleton/issues/1581) over at Skeleton and [added this fix](https://github.com/skeletonlabs/skeleton/pull/1587) not too long ago and it's been working great ever since!