### PR TITLE
fix: SuperDebug collapse button keeps submitting form

### DIFF
--- a/src/lib/client/SuperDebug.svelte
+++ b/src/lib/client/SuperDebug.svelte
@@ -334,7 +334,7 @@
       ></pre>
     {#if collapsible}
       <button
-        on:click={() => setCollapse(!collapsed)}
+        on:click|preventDefault={() => setCollapse(!collapsed)}
         class="super-debug--collapse"
       >
         <svg


### PR DESCRIPTION
I noticed a small bug in the `SuperDebug` component when it is included as a child of a `<form>` element. The bug is that when you click the collapse button it will try to submit the form, which I don't think is intended behaviour.

This patch just adds the `preventDefault` event modifier to the `on:click` button event.

For anyone that isn't familiar with the `preventDefault` modifier, all it does is call `event.preventDefault()` before running the handler. [docs](https://svelte.dev/docs/element-directives#on-eventname)