### PR TITLE
Support `.catchall` for dynamic field names

### DIFF
--- a/src/lib/superValidate.ts
+++ b/src/lib/superValidate.ts
@@ -513,6 +513,10 @@ function getSchemaData<T extends AnyZodObject>(
     catchallTypeInfo = unwrapZodType(
       unwrapSchema(unwrappedSchema._def.catchall)
     );
+
+    if (catchallTypeInfo.zodType._def.typeName === 'ZodNever') {
+      catchallTypeInfo = undefined;
+    }
   }
 
   return {

--- a/src/routes/Navigation.svelte
+++ b/src/routes/Navigation.svelte
@@ -34,6 +34,7 @@
     </li>
     <li><a href="/tests/array-component">Array proxy</a></li>
     <li><a href="/tests/redirect-same-route">Redirect with delay</a></li>
+    <li><a href="/catchall">Catchall</a></li>
   </ul>
 </nav>
 

--- a/src/routes/catchall/+page.server.ts
+++ b/src/routes/catchall/+page.server.ts
@@ -1,0 +1,29 @@
+import { superValidate } from '$lib/superValidate.js';
+import { z } from 'zod';
+import type { Actions, PageServerLoad } from './$types';
+
+const schema = z
+  .object({
+    known_1: z.string().trim(),
+    known_2: z.string().trim()
+  })
+  .catchall(z.number().int().min(1));
+
+export const load = (async () => {
+  const form = superValidate(schema);
+  return { form };
+}) satisfies PageServerLoad;
+
+export const actions: Actions = {
+  async default(event) {
+    console.log('--- POST -------------------------------------------');
+    const data = await event.request.formData();
+    console.log(data);
+
+    const form = await superValidate(data, schema);
+
+    console.log(form.data);
+
+    return { form };
+  }
+};

--- a/src/routes/catchall/+page.svelte
+++ b/src/routes/catchall/+page.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import SuperDebug from '$lib/client/SuperDebug.svelte';
+  import { superForm } from '$lib/client/index.js';
+  import type { PageData } from './$types';
+
+  export let data: PageData;
+
+  let postedData: any;
+
+  const { form, enhance, posted, allErrors } = superForm(data.form, {
+    onUpdated(event) {
+      postedData = event.form.data;
+    }
+  });
+
+  let dynamicInputCount = 2;
+</script>
+
+<a href="/">&lt; Back to start</a>
+
+<SuperDebug label="Form data" data={$form} />
+{#if $posted}
+  {#if $allErrors.length > 0}
+    <SuperDebug label="Errors" data={$allErrors} />
+  {/if}
+{/if}
+
+<form method="post" use:enhance>
+  <label
+    >known 1 <input
+      type="text"
+      name="known_1"
+      bind:value={$form.known_1}
+    /></label
+  >
+  <label
+    >known 2 <input
+      type="text"
+      name="known_2"
+      bind:value={$form.known_2}
+    /></label
+  >
+
+  <div>
+    <button
+      type="button"
+      disabled={dynamicInputCount === 0}
+      on:click={() => dynamicInputCount--}>less inputs</button
+    >
+    <button type="button" on:click={() => dynamicInputCount++}
+      >more inputs</button
+    >
+  </div>
+
+  {#each Array(dynamicInputCount) as _, idx}
+    <label
+      >dynamic number (<code>dynamic_{idx}</code>)
+      <input type="text" name="dynamic_{idx}" /></label
+    >
+  {/each}
+
+  <button>Submit</button>
+</form>


### PR DESCRIPTION
See #289 

I did not add types to the constraints, tainted and errors as I did not really understand the specifics of the `SuperStruct` type :sweat_smile: 