### PR TITLE
Fix: use z.input to support zod transform types

### DIFF
--- a/src/lib/superValidate.ts
+++ b/src/lib/superValidate.ts
@@ -557,7 +557,7 @@ export async function superValidate<
     | FormData
     | URLSearchParams
     | URL
-    | Partial<z.infer<UnwrapEffects<T>>>
+    | Partial<z.input<UnwrapEffects<T>>>
     | null
     | undefined,
   schema: T,

--- a/src/zod-transform.test.ts
+++ b/src/zod-transform.test.ts
@@ -1,0 +1,26 @@
+
+
+import { z } from 'zod';
+import { expect, test } from 'vitest';
+import { superValidate } from '$lib/superValidate';
+
+
+test('Should work without custom transform', async () => {
+    const result = await superValidate({name: 'test-123'}, z.object({
+        name: z.string().min(2)
+    }));
+    expect(result.valid).toEqual(true);
+    expect(result.data).toEqual({name: 'test-123'});
+});
+
+test('Should work with custom transform', async () => {
+    const result = await superValidate({name: 'test-123', stringToNumber: 'test-123'}, z.object({
+        name: z.string().min(2),
+        stringToNumber: z.string().transform((val) => val.length)
+    }));
+    expect(result.valid).toEqual(true);
+    expect(result.data).toEqual({
+        name: 'test-123',
+        stringToNumber: 8
+    })
+});


### PR DESCRIPTION
Hope everything is going well, and happy 2024 👏

We are implementing superforms in our application to replace GraphQl, and today I noticed a small issue.

Superforms does not support custom transforms (at least from a typescript perspective).

I fixed this by using `z.input` instead of `z.infer`. Do you like the solution/tests?

Btw @ciscoheat  - I also noticed a couple of issues with `npm run check` - but ignored them for now?