### PR TITLE
add optional type parameter for arrayProxy

### DIFF
--- a/src/lib/client/proxies.ts
+++ b/src/lib/client/proxies.ts
@@ -237,14 +237,14 @@ function _stringProxy<T extends Record<string, unknown>, Path extends FormPath<T
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ArrayFieldErrors = any[];
 
-export function arrayProxy<T extends Record<string, unknown>, Path extends FormPathArrays<T>>(
+export function arrayProxy<T extends Record<string, unknown>, Path extends FormPathArrays<T>, Values extends unknown[]>(
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	superForm: SuperForm<T, any>,
 	path: Path,
 	options?: { taint?: TaintOption }
 ): {
 	path: Path;
-	values: Writable<FormPathType<T, Path> & unknown[]>;
+	values: Writable<FormPathType<T, Path> & Values>;
 	errors: Writable<string[] | undefined>;
 	valueErrors: Writable<ArrayFieldErrors>;
 } {


### PR DESCRIPTION
When writing a component to encapsulate forms & fields, it's particularly useful to do so when dealing with an array of values.  However, the `arrayProxy` function always returns a `$values` store with a type of `unknown[]` if the type of the form is unknown. It would be nice if we could tell the type system what we expect to receive. For example:

```svelte
<script lang="ts" generics="T extends Record<string, unknown>, V">
	import type { Writable } from 'svelte/store';
	import type {SuperForm, FormPathArrays} from 'sveltekit-superforms';
	import {arrayProxy} from 'sveltekit-superforms'

	export let form: SuperForm<T, any>;
	export let field: FormPathArrays<T>;
	export let newValue: V;

	const { path, values, errors, valueErrors } = arrayProxy<V>(form, field);
	// `values` has type `Writable<V[]>`
</script>

<div>
	<ol>
		{#each $values as value, i}
			<li>
				<!-- `value` has type `V`; can render fields here -->
				<button type="button" title="Delete" on:click={() => ($values = $values.toSpliced(i, 1))}>
					✖️
				</button>
				{#if $fieldErrors && $fieldErrors[i]}
					<div role="alert">{$fieldErrors[i]}</div>
				{/if}
			</li>
		{/each}
		<button type="button" on:click={() => ($values = [...$values, newValue])}>
			Add
		</button>
	</ol>
	{#if $errors}
		<div role="alert">{$errors}</div>
	{/if}
</div>
```

Notice the `arrayProxy<V>(form, field)` at the end of the `<script>` section. This type annotation doesn't currently work; but I wish it did! That's what this pull request is about. I don't know if I'm doing it correctly, or how to properly test it.

The intention of a component like this is so that, somewhere else in the code, you could call it like this:

```svelte
<script lang="ts">
	import ArrayField from '$lib/ArrayField.svelte';
	import { superForm } from 'sveltekit-superforms/client';
	import { z } from 'zod';
	import { zod } from 'sveltekit-superforms/adapters';

	const schema = z.object({
		tags: z.array(z.string().min(1)).nonempty()
	});

	const form = superForm(data.form, {
		validators: zod(schema),
	});
<script>

<ArrayField form={form} field="tags" newValue="" />
```
