### PR TITLE
Feature: Add VineJS Adapter

### DIFF
--- a/.github/ISSUE_TEMPLATE/commercial_support.md
+++ b/.github/ISSUE_TEMPLATE/commercial_support.md
@@ -1,15 +1,15 @@
 ---
-name: Bug report
-about: When something doesn't work as expected
+name: Commercial support
+about: When you need help with Superforms for a commercial project
 title: ''
-labels: bug
+labels: support
 assignees: ''
 ---
 
-- [ ] Before posting an issue, read the [FAQ](https://superforms.rocks/faq) and search the previous issues.
+- [ ] I have within a month made a donation proportionally to the current profit of the project or the company I work for, on the [Superforms website](https://superforms.rocks/support).
 
 **Description**
-A clear and concise description of what the bug is, and, unless obvious, what you expected instead.
+A description of your question. It's also helpful, but not required, if you can tell something about what kind of answer you expect.
 
 **If applicable, a MRE**
 Use one of these stackblitz templates to create a minimal reproducible example that you can link to here:

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
 		"svelte": "3.x || 4.x || >=5.0.0-next.51",
 		"valibot": "^0.28.1",
 		"yup": "^1.3.3",
-		"zod": "^3.22.4"
+		"zod": "^3.22.4",
+		"@vinejs/vine": "^1.7.1"
 	},
 	"peerDependenciesMeta": {
 		"@sinclair/typebox": {
@@ -124,6 +125,9 @@
 		},
 		"zod": {
 			"optional": true
+		},
+		"@vinejs/vine": {
+			"optional": true
 		}
 	},
 	"optionalDependencies": {
@@ -136,6 +140,7 @@
 		"valibot": "^0.28.1",
 		"yup": "^1.3.3",
 		"zod": "^3.22.4",
+		"@vinejs/vine": "^1.7.1",
 		"zod-to-json-schema": "^3.22.4"
 	},
 	"dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  '@vinejs/vine':
-    specifier: ^1.7.1
-    version: 1.7.1
   devalue:
     specifier: ^4.3.2
     version: 4.3.2
@@ -31,6 +28,9 @@ optionalDependencies:
   '@sodaru/yup-to-json-schema':
     specifier: ^2.0.1
     version: 2.0.1
+  '@vinejs/vine':
+    specifier: ^1.7.1
+    version: 1.7.1
   arktype:
     specifier: 1.0.29-alpha
     version: 1.0.29-alpha
@@ -736,7 +736,9 @@ packages:
   /@poppinss/macroable@1.0.1:
     resolution: {integrity: sha512-bO3+rnqGhE+gdx4DOyYjY9jCm2+c5Ncyl2Gmst0w271rIFnsB00btonpdmAqvFNzS8rcas+APGm+47fYMmkpQA==}
     engines: {node: '>=18.16.0'}
+    requiresBuild: true
     dev: false
+    optional: true
 
   /@rollup/rollup-android-arm-eabi@4.9.6:
     resolution: {integrity: sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==}
@@ -996,7 +998,9 @@ packages:
 
   /@types/validator@13.11.9:
     resolution: {integrity: sha512-FCTsikRozryfayPuiI46QzH3fnrOoctTjvOYZkho9BTFLCOZ2rgZJHMOVgCOfttjPJcgOx52EpkY0CMfy87MIw==}
+    requiresBuild: true
     dev: false
+    optional: true
 
   /@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
@@ -1137,11 +1141,14 @@ packages:
   /@vinejs/compiler@2.4.0:
     resolution: {integrity: sha512-qEhp+Ux4wCeyYlQpB5TddjlRRyxbZz4RVYG/UHGnnnn3eOw326dZGCJldOOEl6huBFoOguMUQfhKLLSjJ0v+XQ==}
     engines: {node: '>=18.0.0'}
+    requiresBuild: true
     dev: false
+    optional: true
 
   /@vinejs/vine@1.7.1:
     resolution: {integrity: sha512-24FYCIMrQZbhUKkVyAApz5/eN34FBVuhayty1RyCNvdvYF2TpZpO/+NyjELW3JRtbIDfrAvr1+pYdJfRIovcbA==}
     engines: {node: '>=18.16.0'}
+    requiresBuild: true
     dependencies:
       '@poppinss/macroable': 1.0.1
       '@types/validator': 13.11.9
@@ -1152,6 +1159,7 @@ packages:
       normalize-url: 8.0.0
       validator: 13.11.0
     dev: false
+    optional: true
 
   /@vitest/expect@1.2.2:
     resolution: {integrity: sha512-3jpcdPAD7LwHUUiT2pZTj2U82I2Tcgg2oVPvKxhn6mDI2On6tfvPQTjAI4628GUGDZrCm4Zna9iQHm5cEexOAg==}
@@ -1335,7 +1343,9 @@ packages:
   /camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
+    requiresBuild: true
     dev: false
+    optional: true
 
   /chai@4.4.1:
     resolution: {integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==}
@@ -1416,7 +1426,9 @@ packages:
 
   /dayjs@1.11.10:
     resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
+    requiresBuild: true
     dev: false
+    optional: true
 
   /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -1477,7 +1489,9 @@ packages:
 
   /dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+    requiresBuild: true
     dev: false
+    optional: true
 
   /doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -2241,7 +2255,9 @@ packages:
   /normalize-url@8.0.0:
     resolution: {integrity: sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==}
     engines: {node: '>=14.16'}
+    requiresBuild: true
     dev: false
+    optional: true
 
   /npm-bundled@2.0.1:
     resolution: {integrity: sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==}
@@ -3011,7 +3027,9 @@ packages:
   /validator@13.11.0:
     resolution: {integrity: sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==}
     engines: {node: '>= 0.10'}
+    requiresBuild: true
     dev: false
+    optional: true
 
   /vite-node@1.2.2(sass@1.70.0):
     resolution: {integrity: sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@vinejs/vine':
+    specifier: ^1.7.1
+    version: 1.7.1
   devalue:
     specifier: ^4.3.2
     version: 4.3.2
@@ -730,6 +733,11 @@ packages:
     resolution: {integrity: sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==}
     dev: true
 
+  /@poppinss/macroable@1.0.1:
+    resolution: {integrity: sha512-bO3+rnqGhE+gdx4DOyYjY9jCm2+c5Ncyl2Gmst0w271rIFnsB00btonpdmAqvFNzS8rcas+APGm+47fYMmkpQA==}
+    engines: {node: '>=18.16.0'}
+    dev: false
+
   /@rollup/rollup-android-arm-eabi@4.9.6:
     resolution: {integrity: sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==}
     cpu: [arm]
@@ -986,6 +994,10 @@ packages:
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
     dev: true
 
+  /@types/validator@13.11.9:
+    resolution: {integrity: sha512-FCTsikRozryfayPuiI46QzH3fnrOoctTjvOYZkho9BTFLCOZ2rgZJHMOVgCOfttjPJcgOx52EpkY0CMfy87MIw==}
+    dev: false
+
   /@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -1121,6 +1133,25 @@ packages:
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
+
+  /@vinejs/compiler@2.4.0:
+    resolution: {integrity: sha512-qEhp+Ux4wCeyYlQpB5TddjlRRyxbZz4RVYG/UHGnnnn3eOw326dZGCJldOOEl6huBFoOguMUQfhKLLSjJ0v+XQ==}
+    engines: {node: '>=18.0.0'}
+    dev: false
+
+  /@vinejs/vine@1.7.1:
+    resolution: {integrity: sha512-24FYCIMrQZbhUKkVyAApz5/eN34FBVuhayty1RyCNvdvYF2TpZpO/+NyjELW3JRtbIDfrAvr1+pYdJfRIovcbA==}
+    engines: {node: '>=18.16.0'}
+    dependencies:
+      '@poppinss/macroable': 1.0.1
+      '@types/validator': 13.11.9
+      '@vinejs/compiler': 2.4.0
+      camelcase: 8.0.0
+      dayjs: 1.11.10
+      dlv: 1.1.3
+      normalize-url: 8.0.0
+      validator: 13.11.0
+    dev: false
 
   /@vitest/expect@1.2.2:
     resolution: {integrity: sha512-3jpcdPAD7LwHUUiT2pZTj2U82I2Tcgg2oVPvKxhn6mDI2On6tfvPQTjAI4628GUGDZrCm4Zna9iQHm5cEexOAg==}
@@ -1301,6 +1332,11 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
+    dev: false
+
   /chai@4.4.1:
     resolution: {integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==}
     engines: {node: '>=4'}
@@ -1378,6 +1414,10 @@ packages:
     hasBin: true
     dev: true
 
+  /dayjs@1.11.10:
+    resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
+    dev: false
+
   /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -1434,6 +1474,10 @@ packages:
     dependencies:
       path-type: 4.0.0
     dev: true
+
+  /dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+    dev: false
 
   /doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -2193,6 +2237,11 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /normalize-url@8.0.0:
+    resolution: {integrity: sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==}
+    engines: {node: '>=14.16'}
+    dev: false
 
   /npm-bundled@2.0.1:
     resolution: {integrity: sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==}
@@ -2958,6 +3007,11 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /validator@13.11.0:
+    resolution: {integrity: sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==}
+    engines: {node: '>= 0.10'}
+    dev: false
 
   /vite-node@1.2.2(sass@1.70.0):
     resolution: {integrity: sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==}

--- a/src/lib/adapters/adapters.ts
+++ b/src/lib/adapters/adapters.ts
@@ -26,7 +26,8 @@ export type ValidationLibrary =
 	| 'typebox'
 	| 'valibot'
 	| 'yup'
-	| 'zod';
+	| 'zod'
+	| 'vine';
 
 export type AdapterOptions<T extends Schema> = {
 	jsonSchema?: JSONSchema;

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -7,6 +7,7 @@ export { typebox, typeboxClient } from './typebox.js';
 export { valibot, valibotClient } from './valibot.js';
 export { yup, yupClient } from './yup.js';
 export { zod, zodClient } from './zod.js';
+export { vine, vineClient } from "./vine.js"
 
 /*
 // Cannot use due to moduleResolution problem: https://github.com/ianstormtaylor/superstruct/issues/1200

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -7,7 +7,7 @@ export { typebox, typeboxClient } from './typebox.js';
 export { valibot, valibotClient } from './valibot.js';
 export { yup, yupClient } from './yup.js';
 export { zod, zodClient } from './zod.js';
-export { vine, vineClient } from "./vine.js"
+export { vine, vineClient } from './vine.js';
 
 /*
 // Cannot use due to moduleResolution problem: https://github.com/ianstormtaylor/superstruct/issues/1200

--- a/src/lib/adapters/typeSchema.ts
+++ b/src/lib/adapters/typeSchema.ts
@@ -16,6 +16,13 @@ import type { Runtype, Static } from 'runtypes';
 import type { Struct, Infer as Infer$2 } from 'superstruct';
 */
 
+type Replace<T, From, To> =
+	NonNullable<T> extends From
+		? To | Exclude<T, From>
+		: NonNullable<T> extends object
+			? { [K in keyof T]: Replace<T[K], From, To> }
+			: T;
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type IfDefined<T> = any extends T ? never : T;
 type UnknownIfNever<T> = [T] extends [never] ? unknown : T;
@@ -105,7 +112,9 @@ interface ZodResolver extends Resolver {
 
 interface VineResolver extends Resolver {
 	base: SchemaTypes;
-	input: this['schema'] extends SchemaTypes ? VineInfer<this['schema']> : never;
+	input: this['schema'] extends SchemaTypes
+		? Replace<VineInfer<this['schema']>, Date, string>
+		: never;
 	output: this['schema'] extends SchemaTypes ? VineInfer<this['schema']> : never;
 }
 

--- a/src/lib/adapters/typeSchema.ts
+++ b/src/lib/adapters/typeSchema.ts
@@ -104,7 +104,7 @@ interface ZodResolver extends Resolver {
 }
 
 interface VineResolver extends Resolver {
-	base: SchemaTypes
+	base: SchemaTypes;
 }
 
 /*

--- a/src/lib/adapters/typeSchema.ts
+++ b/src/lib/adapters/typeSchema.ts
@@ -4,7 +4,7 @@ import type { AnySchema } from 'joi';
 import type { BaseSchema, BaseSchemaAsync, Input, Output } from 'valibot';
 import type { Schema as Schema$2, InferType } from 'yup';
 import type { ZodSchema, input, output } from 'zod';
-import type { SchemaTypes } from '@vinejs/vine/types';
+import type { SchemaTypes, Infer as VineInfer } from '@vinejs/vine/types';
 
 /*
 import type { SchemaObject } from 'ajv';
@@ -105,6 +105,8 @@ interface ZodResolver extends Resolver {
 
 interface VineResolver extends Resolver {
 	base: SchemaTypes;
+	input: this['schema'] extends SchemaTypes ? VineInfer<this['schema']> : never;
+	output: this['schema'] extends SchemaTypes ? VineInfer<this['schema']> : never;
 }
 
 /*

--- a/src/lib/adapters/typeSchema.ts
+++ b/src/lib/adapters/typeSchema.ts
@@ -4,6 +4,8 @@ import type { AnySchema } from 'joi';
 import type { BaseSchema, BaseSchemaAsync, Input, Output } from 'valibot';
 import type { Schema as Schema$2, InferType } from 'yup';
 import type { ZodSchema, input, output } from 'zod';
+import type { SchemaTypes } from '@vinejs/vine/types';
+
 /*
 import type { SchemaObject } from 'ajv';
 import type { Type as Type$1 } from '@deepkit/type';
@@ -101,6 +103,10 @@ interface ZodResolver extends Resolver {
 	output: this['schema'] extends ZodSchema ? output<this['schema']> : never;
 }
 
+interface VineResolver extends Resolver {
+	base: SchemaTypes
+}
+
 /*
 interface AjvResolver extends Resolver {
 	base: SchemaObject;
@@ -148,6 +154,7 @@ type Registry = {
 	valibot: ValibotResolver;
 	yup: YupResolver;
 	zod: ZodResolver;
+	vine: VineResolver;
 	/*
 		ajv: AjvResolver;
     deepkit: DeepkitResolver;

--- a/src/lib/adapters/vine.ts
+++ b/src/lib/adapters/vine.ts
@@ -27,7 +27,7 @@ async function validate<T extends SchemaTypes>(
 		if (e instanceof errors.E_VALIDATION_ERROR) {
 			res = {
 				success: false,
-				issues: e.messages.map((m: { field: string; message: string; }) => ({
+				issues: e.messages.map((m: { field: string; message: string }) => ({
 					path: [m.field as string],
 					message: m.message as string
 				})) as Array<ValidationIssue>

--- a/src/lib/adapters/vine.ts
+++ b/src/lib/adapters/vine.ts
@@ -16,19 +16,19 @@ import type { SchemaTypes } from '@vinejs/vine/types';
 
 async function validate<T extends SchemaTypes>(schema:T, data:unknown): Promise<ValidationResult<Infer<T>>> {
     let res = null;
+    const vine = new Vine()
     try {
-        const output = await new Vine().validate({schema, data})
+        const output = await vine.validate({schema, data})
         res = {
             success:true,
             data: output as Infer<T>
         }
     } catch (e) {
         if (e instanceof errors.E_VALIDATION_ERROR) {
-            console.log(e.messages)
             res = {
                 success:false,
                 issues: e.messages.map((m) => ({
-                    path: m.field as string,
+                    path: [m.field as string],
                     message: m.message as string
                 })) as Array<ValidationIssue>
             }

--- a/src/lib/adapters/vine.ts
+++ b/src/lib/adapters/vine.ts
@@ -1,7 +1,5 @@
 import {
 	type ValidationAdapter,
-	type Infer,
-	type InferIn,
 	createAdapter,
 	type ValidationResult,
 	type ClientValidationAdapter,
@@ -16,20 +14,20 @@ import type { SchemaTypes } from '@vinejs/vine/types';
 async function validate<T extends SchemaTypes>(
 	schema: T,
 	data: unknown
-): Promise<ValidationResult<Infer<T>>> {
+): Promise<ValidationResult<Record<string, unknown>>> {
 	let res = null;
 	const vine = new Vine();
 	try {
 		const output = await vine.validate({ schema, data });
 		res = {
 			success: true,
-			data: output as Infer<T>
+			data: output as Record<string, unknown>
 		};
 	} catch (e) {
 		if (e instanceof errors.E_VALIDATION_ERROR) {
 			res = {
 				success: false,
-				issues: e.messages.map((m) => ({
+				issues: e.messages.map((m: { field: string; message: string; }) => ({
 					path: [m.field as string],
 					message: m.message as string
 				})) as Array<ValidationIssue>
@@ -39,14 +37,14 @@ async function validate<T extends SchemaTypes>(
 		if (res === null) {
 			return { success: false, issues: [] };
 		}
-		return res as ValidationResult<Infer<T>>;
+		return res as ValidationResult<Record<string, unknown>>;
 	}
 }
 
 function _vine<T extends SchemaTypes>(
 	schema: T,
 	options: RequiredDefaultsOptions<T>
-): ValidationAdapter<Infer<T>, InferIn<T>> {
+): ValidationAdapter<Record<string, unknown>> {
 	return createAdapter({
 		superFormValidationLibrary: 'vine',
 		validate: async (data: unknown) => validate(schema, data),
@@ -57,7 +55,7 @@ function _vine<T extends SchemaTypes>(
 
 function _vineClient<T extends SchemaTypes>(
 	schema: T
-): ClientValidationAdapter<Infer<T>, InferIn<T>> {
+): ClientValidationAdapter<Record<string, unknown>> {
 	return {
 		superFormValidationLibrary: 'vine',
 		validate: async (data) => validate(schema, data)

--- a/src/lib/adapters/vine.ts
+++ b/src/lib/adapters/vine.ts
@@ -5,7 +5,9 @@ import {
 	type ClientValidationAdapter,
 	type ValidationIssue,
 	createJsonSchema,
-	type RequiredDefaultsOptions
+	type RequiredDefaultsOptions,
+	type Infer,
+	type InferIn
 } from './adapters.js';
 import { memoize } from '$lib/memoize.js';
 import { Vine, errors } from '@vinejs/vine';
@@ -14,37 +16,33 @@ import type { SchemaTypes } from '@vinejs/vine/types';
 async function validate<T extends SchemaTypes>(
 	schema: T,
 	data: unknown
-): Promise<ValidationResult<Record<string, unknown>>> {
-	let res = null;
+): Promise<ValidationResult<Infer<T>>> {
 	const vine = new Vine();
 	try {
 		const output = await vine.validate({ schema, data });
-		res = {
+		return {
 			success: true,
-			data: output as Record<string, unknown>
+			data: output as Infer<T>
 		};
 	} catch (e) {
 		if (e instanceof errors.E_VALIDATION_ERROR) {
-			res = {
+			return {
 				success: false,
 				issues: e.messages.map((m: { field: string; message: string }) => ({
 					path: [m.field as string],
 					message: m.message as string
 				})) as Array<ValidationIssue>
 			};
-		}
-	} finally {
-		if (res === null) {
+		} else {
 			return { success: false, issues: [] };
 		}
-		return res as ValidationResult<Record<string, unknown>>;
 	}
 }
 
 function _vine<T extends SchemaTypes>(
 	schema: T,
 	options: RequiredDefaultsOptions<T>
-): ValidationAdapter<Record<string, unknown>> {
+): ValidationAdapter<Infer<T>, InferIn<T>> {
 	return createAdapter({
 		superFormValidationLibrary: 'vine',
 		validate: async (data: unknown) => validate(schema, data),
@@ -55,7 +53,7 @@ function _vine<T extends SchemaTypes>(
 
 function _vineClient<T extends SchemaTypes>(
 	schema: T
-): ClientValidationAdapter<Record<string, unknown>> {
+): ClientValidationAdapter<Infer<T>, InferIn<T>> {
 	return {
 		superFormValidationLibrary: 'vine',
 		validate: async (data) => validate(schema, data)

--- a/src/lib/adapters/vine.ts
+++ b/src/lib/adapters/vine.ts
@@ -1,0 +1,58 @@
+import {
+	type AdapterOptions,
+	type ValidationAdapter,
+	type Infer,
+	type InferIn,
+	createAdapter,
+	type ValidationResult,
+	type ClientValidationAdapter,
+    type ValidationIssue
+} from './adapters.js';
+import { memoize } from '$lib/memoize.js';
+import { Vine, errors,  } from "@vinejs/vine"
+import type { SchemaTypes } from '@vinejs/vine/types';
+
+async function validate<T extends SchemaTypes>(schema:T, data:unknown): Promise<ValidationResult<Infer<T>>> {
+    let res = null;
+    try {
+        const output = await new Vine().validate({schema, data})
+        res = {
+            success:true,
+            data: output as Infer<T>
+        }
+    } catch (e) {
+        if (e instanceof errors.E_VALIDATION_ERROR) {
+            console.log(e.messages)
+            res = {
+                success:false,
+                issues: e.messages.map((m) => ({
+                    path: m.field as string,
+                    message: m.message as string
+                })) as Array<ValidationIssue>
+            }
+          }
+    } finally {
+        if (res === null) {
+            return {success:false, issues:[]}
+        }
+        return res as ValidationResult<Infer<T>>
+    }
+}
+
+function _vine<T extends SchemaTypes>(schema:T): ValidationAdapter<Infer<T>, InferIn<T>> {
+    return createAdapter({
+        superFormValidationLibrary:"vine",
+        validate: async(data: unknown) => validate(schema, data),
+        jsonSchema: schema
+    })
+}
+
+function _vineClient<T extends SchemaTypes>(schema:T): ClientValidationAdapter<Infer<T>, InferIn<T>> {
+    return {
+        superFormValidationLibrary:"vine",
+        validate: async (data) => validate(schema, data)
+    }
+}
+
+export const typebox = /* @__PURE__ */ memoize(_vine);
+export const typeboxClient = /* @__PURE__ */ memoize(_vineClient);

--- a/src/lib/adapters/vine.ts
+++ b/src/lib/adapters/vine.ts
@@ -6,7 +6,9 @@ import {
 	createAdapter,
 	type ValidationResult,
 	type ClientValidationAdapter,
-    type ValidationIssue
+    type ValidationIssue,
+    createJsonSchema,
+    type RequiredDefaultsOptions
 } from './adapters.js';
 import { memoize } from '$lib/memoize.js';
 import { Vine, errors,  } from "@vinejs/vine"
@@ -39,11 +41,11 @@ async function validate<T extends SchemaTypes>(schema:T, data:unknown): Promise<
     }
 }
 
-function _vine<T extends SchemaTypes>(schema:T): ValidationAdapter<Infer<T>, InferIn<T>> {
+function _vine<T extends SchemaTypes>(schema:T, options: RequiredDefaultsOptions<T>): ValidationAdapter<Infer<T>, InferIn<T>> {
     return createAdapter({
         superFormValidationLibrary:"vine",
         validate: async(data: unknown) => validate(schema, data),
-        jsonSchema: schema
+        jsonSchema: createJsonSchema(options)
     })
 }
 
@@ -54,5 +56,5 @@ function _vineClient<T extends SchemaTypes>(schema:T): ClientValidationAdapter<I
     }
 }
 
-export const typebox = /* @__PURE__ */ memoize(_vine);
-export const typeboxClient = /* @__PURE__ */ memoize(_vineClient);
+export const vine = /* @__PURE__ */ memoize(_vine);
+export const vineClient = /* @__PURE__ */ memoize(_vineClient);

--- a/src/lib/adapters/vine.ts
+++ b/src/lib/adapters/vine.ts
@@ -44,7 +44,8 @@ function _vine<T extends SchemaTypes>(schema:T, options: RequiredDefaultsOptions
     return createAdapter({
         superFormValidationLibrary:"vine",
         validate: async(data: unknown) => validate(schema, data),
-        jsonSchema: createJsonSchema(options)
+        jsonSchema: createJsonSchema(options),
+        defaults: options.defaults
     })
 }
 

--- a/src/lib/adapters/vine.ts
+++ b/src/lib/adapters/vine.ts
@@ -1,5 +1,4 @@
 import {
-	type AdapterOptions,
 	type ValidationAdapter,
 	type Infer,
 	type InferIn,

--- a/src/lib/adapters/vine.ts
+++ b/src/lib/adapters/vine.ts
@@ -5,55 +5,63 @@ import {
 	createAdapter,
 	type ValidationResult,
 	type ClientValidationAdapter,
-    type ValidationIssue,
-    createJsonSchema,
-    type RequiredDefaultsOptions
+	type ValidationIssue,
+	createJsonSchema,
+	type RequiredDefaultsOptions
 } from './adapters.js';
 import { memoize } from '$lib/memoize.js';
-import { Vine, errors,  } from "@vinejs/vine"
+import { Vine, errors } from '@vinejs/vine';
 import type { SchemaTypes } from '@vinejs/vine/types';
 
-async function validate<T extends SchemaTypes>(schema:T, data:unknown): Promise<ValidationResult<Infer<T>>> {
-    let res = null;
-    const vine = new Vine()
-    try {
-        const output = await vine.validate({schema, data})
-        res = {
-            success:true,
-            data: output as Infer<T>
-        }
-    } catch (e) {
-        if (e instanceof errors.E_VALIDATION_ERROR) {
-            res = {
-                success:false,
-                issues: e.messages.map((m) => ({
-                    path: [m.field as string],
-                    message: m.message as string
-                })) as Array<ValidationIssue>
-            }
-          }
-    } finally {
-        if (res === null) {
-            return {success:false, issues:[]}
-        }
-        return res as ValidationResult<Infer<T>>
-    }
+async function validate<T extends SchemaTypes>(
+	schema: T,
+	data: unknown
+): Promise<ValidationResult<Infer<T>>> {
+	let res = null;
+	const vine = new Vine();
+	try {
+		const output = await vine.validate({ schema, data });
+		res = {
+			success: true,
+			data: output as Infer<T>
+		};
+	} catch (e) {
+		if (e instanceof errors.E_VALIDATION_ERROR) {
+			res = {
+				success: false,
+				issues: e.messages.map((m) => ({
+					path: [m.field as string],
+					message: m.message as string
+				})) as Array<ValidationIssue>
+			};
+		}
+	} finally {
+		if (res === null) {
+			return { success: false, issues: [] };
+		}
+		return res as ValidationResult<Infer<T>>;
+	}
 }
 
-function _vine<T extends SchemaTypes>(schema:T, options: RequiredDefaultsOptions<T>): ValidationAdapter<Infer<T>, InferIn<T>> {
-    return createAdapter({
-        superFormValidationLibrary:"vine",
-        validate: async(data: unknown) => validate(schema, data),
-        jsonSchema: createJsonSchema(options),
-        defaults: options.defaults
-    })
+function _vine<T extends SchemaTypes>(
+	schema: T,
+	options: RequiredDefaultsOptions<T>
+): ValidationAdapter<Infer<T>, InferIn<T>> {
+	return createAdapter({
+		superFormValidationLibrary: 'vine',
+		validate: async (data: unknown) => validate(schema, data),
+		jsonSchema: createJsonSchema(options),
+		defaults: options.defaults
+	});
 }
 
-function _vineClient<T extends SchemaTypes>(schema:T): ClientValidationAdapter<Infer<T>, InferIn<T>> {
-    return {
-        superFormValidationLibrary:"vine",
-        validate: async (data) => validate(schema, data)
-    }
+function _vineClient<T extends SchemaTypes>(
+	schema: T
+): ClientValidationAdapter<Infer<T>, InferIn<T>> {
+	return {
+		superFormValidationLibrary: 'vine',
+		validate: async (data) => validate(schema, data)
+	};
 }
 
 export const vine = /* @__PURE__ */ memoize(_vine);

--- a/src/tests/superValidate.test.ts
+++ b/src/tests/superValidate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, assert, beforeEach } from 'vitest';
-import type { ValidationAdapter } from '$lib/adapters/index.js';
+import type { Infer, ValidationAdapter } from '$lib/adapters/index.js';
 import { Foo, bigZodSchema } from './data.js';
 import { constraints, type InputConstraints } from '$lib/jsonSchema/constraints.js';
 import { defaultValues } from '$lib/jsonSchema/schemaDefaults.js';
@@ -43,8 +43,8 @@ import {
 	array as yupArray,
 	date as yupDate
 } from 'yup';
-import {vine} from "$lib/adapters/vine.js"
-import Vine from "@vinejs/vine"
+import { vine } from '$lib/adapters/vine.js';
+import Vine from '@vinejs/vine';
 import { traversePath } from '$lib/traversal.js';
 import { splitPath } from '$lib/stringPath.js';
 
@@ -403,18 +403,23 @@ describe('Zod', () => {
 
 /////////////////////////////////////////////////////////////////////
 
-describe("vine", () => {
-	const schema = Vine.object(({
-		name: Vine.string().parse(v => v ?? 'Unknown'),
+describe('vine', () => {
+	const schema = Vine.object({
+		name: Vine.string()
+			.parse((v) => v ?? 'Unknown')
+			.optional(),
 		email: Vine.string().email(),
 		tags: Vine.array(Vine.string().minLength(2)).minLength(3),
 		score: Vine.number().min(0),
-		date: Vine.date().parse(v => v ?? undefined),
+		date: Vine.date()
+			.parse((v) => v ?? undefined)
+			.optional(),
 		nospace: Vine.string().regex(nospacePattern).optional()
-	}))
-	const adapter = vine(schema, {defaults})
-	schemaTest(adapter, ['email', 'date', 'nospace', 'tags'], 'simple', true);
-})
+	});
+	type T = Infer<typeof schema>;
+	const adapter = vine(schema, { defaults });
+	schemaTest(adapter, ['email', 'nospace', 'tags'], 'simple', true);
+});
 
 ///// Common ////////////////////////////////////////////////////////
 
@@ -515,8 +520,6 @@ function schemaTest(
 		);
 		return merge(filteredDefaults, invalidData);
 	}
-
-
 
 	it('with schema only', async () => {
 		const output = await superValidate(adapter);

--- a/src/tests/superValidate.test.ts
+++ b/src/tests/superValidate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, assert, beforeEach } from 'vitest';
-import type { Infer, ValidationAdapter } from '$lib/adapters/index.js';
+import type { ValidationAdapter } from '$lib/adapters/index.js';
 import { Foo, bigZodSchema } from './data.js';
 import { constraints, type InputConstraints } from '$lib/jsonSchema/constraints.js';
 import { defaultValues } from '$lib/jsonSchema/schemaDefaults.js';
@@ -416,8 +416,17 @@ describe('vine', () => {
 			.optional(),
 		nospace: Vine.string().regex(nospacePattern).optional()
 	});
-	type T = Infer<typeof schema>;
+
 	const adapter = vine(schema, { defaults });
+
+	it('should accept string as input for inferred Date fields', async () => {
+		const date = '2024-02-14';
+		const form = await superValidate({ ...validData, date }, adapter);
+
+		const realDate: Date | undefined = form.data.date;
+		expect(realDate).toEqual(new Date(date + 'T00:00:00'));
+	});
+
 	schemaTest(adapter, ['email', 'nospace', 'tags'], 'simple', true);
 });
 

--- a/src/tests/superValidate.test.ts
+++ b/src/tests/superValidate.test.ts
@@ -409,7 +409,7 @@ describe("vine", () => {
 		email: Vine.string().email(),
 		tags: Vine.array(Vine.string().minLength(2)).minLength(3),
 		score: Vine.number().min(0),
-		date: Vine.date().optional(),
+		date: Vine.date().parse(v => v ?? undefined),
 		nospace: Vine.string().regex(nospacePattern).optional()
 	}))
 	const adapter = vine(schema, {defaults})
@@ -484,7 +484,7 @@ function schemaTest(
 	
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	function expectErrors(errors: ErrorFields, errorMessages: Record<string, any>) {
-		//console.log('🚀 ~ expectErrors ~ errorMessages:', errorMessages);
+		console.log('🚀 ~ expectErrors ~ errorMessages:', errorMessages);
 
 		if (errors.includes('nospace')) expect(errorMessages.nospace).toBeTruthy();
 		if (errors.includes('email')) expect(errorMessages.email).toBeTruthy();

--- a/src/tests/superValidate.test.ts
+++ b/src/tests/superValidate.test.ts
@@ -480,8 +480,8 @@ function schemaTest(
 	adapterType: 'full' | 'simple' = 'full',
 	dateAsString: boolean = false
 ) {
-	const validD = {...validData, date: dateAsString ? "2024-01-01" : validData.date}
-	
+	const validD = { ...validData, date: dateAsString ? '2024-01-01' : validData.date };
+
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	function expectErrors(errors: ErrorFields, errorMessages: Record<string, any>) {
 		// console.log('🚀 ~ expectErrors ~ errorMessages:', errorMessages);
@@ -556,7 +556,10 @@ function schemaTest(
 		expect(output.errors).toEqual({});
 		expect(output.valid).toEqual(true);
 		expect(output.data).not.toBe(validD);
-		expect(output.data).toEqual({...validD, date: dateAsString ? new Date(validD.date) : validD.date});
+		expect(output.data).toEqual({
+			...validD,
+			date: dateAsString ? new Date(validD.date + 'T00:00:00') : validD.date
+		});
 		expect(output.message).toBeUndefined();
 		expectConstraints(output.constraints);
 	});

--- a/src/tests/superValidate.test.ts
+++ b/src/tests/superValidate.test.ts
@@ -410,7 +410,7 @@ describe("vine", () => {
 		tags: Vine.array(Vine.string().minLength(2)).minLength(3),
 		score: Vine.number().min(0),
 		date: Vine.date().optional(),
-		noSpace: Vine.string().regex(nospacePattern).optional()
+		nospace: Vine.string().regex(nospacePattern).optional()
 	}))
 	const adapter = vine(schema, {defaults})
 	schemaTest(adapter, ['email', 'date', 'nospace', 'tags'], 'simple', true);

--- a/src/tests/superValidate.test.ts
+++ b/src/tests/superValidate.test.ts
@@ -56,6 +56,8 @@ import {
 	array as yupArray,
 	date as yupDate
 } from 'yup';
+import {vine} from "$lib/adapters/vine.js"
+import Vine from "@vinejs/vine"
 import { traversePath } from '$lib/traversal.js';
 import { splitPath } from '$lib/stringPath.js';
 
@@ -345,6 +347,20 @@ describe('Zod', () => {
 
 	schemaTest(zod(schema));
 });
+
+/////////////////////////////////////////////////////////////////////
+
+describe("vine", () => {
+	const schema = Vine.object(({
+		name: Vine.string().optional(),
+		email: Vine.string().email(),
+		tags: Vine.array(Vine.string().minLength(2)).minLength(3),
+		score: Vine.number().min(0),
+		date: Vine.date().optional(),
+		noSpace: Vine.string().regex(nospacePattern).optional()
+	}))
+	schemaTest(vine(schema, { defaults }), ['email', 'date', 'nospace', 'tags'])
+})
 
 ///// Common ////////////////////////////////////////////////////////
 

--- a/src/tests/superValidate.test.ts
+++ b/src/tests/superValidate.test.ts
@@ -405,15 +405,11 @@ describe('Zod', () => {
 
 describe('vine', () => {
 	const schema = Vine.object({
-		name: Vine.string()
-			.parse((v) => v ?? 'Unknown')
-			.optional(),
+		name: Vine.string().optional(),
 		email: Vine.string().email(),
 		tags: Vine.array(Vine.string().minLength(2)).minLength(3),
 		score: Vine.number().min(0),
-		date: Vine.date()
-			.parse((v) => v ?? undefined)
-			.optional(),
+		date: Vine.date().optional(),
 		nospace: Vine.string().regex(nospacePattern).optional()
 	});
 

--- a/src/tests/superValidate.test.ts
+++ b/src/tests/superValidate.test.ts
@@ -484,7 +484,7 @@ function schemaTest(
 	
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	function expectErrors(errors: ErrorFields, errorMessages: Record<string, any>) {
-		console.log('🚀 ~ expectErrors ~ errorMessages:', errorMessages);
+		// console.log('🚀 ~ expectErrors ~ errorMessages:', errorMessages);
 
 		if (errors.includes('nospace')) expect(errorMessages.nospace).toBeTruthy();
 		if (errors.includes('email')) expect(errorMessages.email).toBeTruthy();

--- a/src/tests/superValidate.test.ts
+++ b/src/tests/superValidate.test.ts
@@ -359,7 +359,8 @@ describe("vine", () => {
 		date: Vine.date().optional(),
 		noSpace: Vine.string().regex(nospacePattern).optional()
 	}))
-	schemaTest(vine(schema, { defaults }))
+	const adapter = vine(schema, {defaults})
+	schemaTest(adapter, ['email', 'date', 'nospace', 'tags'], 'simple');
 })
 
 ///// Common ////////////////////////////////////////////////////////

--- a/src/tests/superValidate.test.ts
+++ b/src/tests/superValidate.test.ts
@@ -352,14 +352,14 @@ describe('Zod', () => {
 
 describe("vine", () => {
 	const schema = Vine.object(({
-		name: Vine.string().optional(),
+		name: Vine.string().parse(v => {v ?? 'Unknown'}).optional(),
 		email: Vine.string().email(),
 		tags: Vine.array(Vine.string().minLength(2)).minLength(3),
 		score: Vine.number().min(0),
 		date: Vine.date().optional(),
 		noSpace: Vine.string().regex(nospacePattern).optional()
 	}))
-	schemaTest(vine(schema, { defaults }), ['email', 'date', 'nospace', 'tags'])
+	schemaTest(vine(schema, { defaults }))
 })
 
 ///// Common ////////////////////////////////////////////////////////


### PR DESCRIPTION
This feature adds VineJS to the available adapters for Superforms and solves issue #334.

Changes:
- add VineJS adapter and types
- change tests so they can optionally accept date strings instead of a DateTime instance via an optional flag

Big thanks to @ciscoheat for helping me through some integration issues during development and to the VineJS maintainers for answering some of my (not so-clever) questions