### PR TITLE
Fix FormPath types

### DIFF
--- a/src/lib/stringPath.ts
+++ b/src/lib/stringPath.ts
@@ -19,7 +19,6 @@ export function mergePath(path: (string | number | symbol)[]) {
 	}, '');
 }
 
-type BuiltInObjects = Date | Set<unknown> | File;
 type DictOrArray = Record<PropertyKey, unknown> | unknown[];
 
 /**
@@ -83,9 +82,7 @@ type StringPath<
 		path: '';
 		type: never;
 	}
-> = T extends BuiltInObjects
-	? If<Options, 'filter', 'leaves' | 'all', Options['path'], never, T>
-	: T extends (infer U)[]
+> = T extends (infer U)[]
 		?
 				| If<Options, 'objAppend', string, Concat<Options['path'], Options['objAppend']>, never, T>
 				| If<Options, 'filter', 'arrays' | 'all', Options['path'], never, T>

--- a/src/lib/stringPath.ts
+++ b/src/lib/stringPath.ts
@@ -20,6 +20,7 @@ export function mergePath(path: (string | number | symbol)[]) {
 }
 
 type BuiltInObjects = Date | Set<unknown> | File;
+type DictOrArray = Record<PropertyKey, unknown> | unknown[];
 
 /**
  * Lists all paths in an object as string accessors.
@@ -88,7 +89,7 @@ type StringPath<
 		?
 				| If<Options, 'objAppend', string, Concat<Options['path'], Options['objAppend']>, never, T>
 				| If<Options, 'filter', 'arrays' | 'all', Options['path'], never, T>
-				| (NonNullable<U> extends object
+				| (NonNullable<U> extends DictOrArray
 						? StringPath<
 								NonNullable<U>,
 								{
@@ -100,7 +101,7 @@ type StringPath<
 							>
 						: If<Options, 'filter', 'leaves' | 'all', `${Options['path']}[${number}]`, never, T>)
 		: {
-				[K in Extract<AllKeys<T>, string>]: NonNullable<T[K]> extends object
+				[K in Extract<AllKeys<T>, string>]: NonNullable<T[K]> extends DictOrArray
 					?
 							| If<
 									Options,
@@ -122,7 +123,7 @@ type StringPath<
 												never,
 												T[K]
 											>
-										: NonNullable<U> extends object
+										: NonNullable<U> extends DictOrArray
 											? IsAny<T[K]> extends true
 												? Concat<Options['path'], `${K}[${number}]`>
 												: If<
@@ -141,7 +142,7 @@ type StringPath<
 													never,
 													U
 												>)
-								| (NonNullable<U> extends object
+								| (NonNullable<U> extends DictOrArray
 										? StringPath<
 												NonNullable<U>,
 												{


### PR DESCRIPTION
This PR fixes a couple of issues, which can be easily explained with this [playground](https://codesandbox.io/p/sandbox/formpath-fixes-vgngnq?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clvsrcixi00063b6hm6wbdh5s%2522%252C%2522sizes%2522%253A%255B100%252C0%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clvsrcixh00023b6hlw7dgk6v%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clvsrcixh00033b6h8hyzz6a7%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clvsrcixh00053b6h90q4vv34%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B100%252C0%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clvsrcixh00023b6hlw7dgk6v%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clvsrcixh00013b6hs1syrb4s%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252Fsrc%252Findex.ts%2522%257D%255D%252C%2522id%2522%253A%2522clvsrcixh00023b6hlw7dgk6v%2522%252C%2522activeTabId%2522%253A%2522clvsrcixh00013b6hs1syrb4s%2522%257D%252C%2522clvsrcixh00053b6h90q4vv34%2522%253A%257B%2522id%2522%253A%2522clvsrcixh00053b6h90q4vv34%2522%252C%2522tabs%2522%253A%255B%255D%257D%252C%2522clvsrcixh00033b6h8hyzz6a7%2522%253A%257B%2522tabs%2522%253A%255B%255D%252C%2522id%2522%253A%2522clvsrcixh00033b6h8hyzz6a7%2522%257D%257D%252C%2522showDevtools%2522%253Afalse%252C%2522showShells%2522%253Afalse%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D).

## Issue Summary
By extending `object` you are extending all types of objects (including classes with methods and properties). Instead you should extend this type:

```ts
type DictOrArray = Record<PropertyKey, unknown> | unknown[];
```

This type only extends basic objects and arrays. No classes or branded types. An added benefit of this is that you no longer need to check built-in class types (ex. Date, Blob, etc). This tweak automatically handles all of those types correctly.

## Detailed Examples of Issues

The playground linked above showcases this as well.

```ts
import { ExampleData, Id } from "./example";

/**
 * Example 1: Paths from Class Methods/Properties
 */
import { FormPath } from "sveltekit-superforms";
import { FormPath as FixedFormPath } from "./fixed";

// When you use the built-in FormPath helper, it adds a path for every class property/method.
// This is undesirable. Instead, it should only provide paths for basic objects and arrays.

type BadFormPath = FormPath<ExampleData>;
// type BadFormPath = "id" | "message" | "date" | "user" | "tags" | "id.charAt" | "id.charCodeAt" | "id.concat"
//   | "id.indexOf" | "id.lastIndexOf" | "id.localeCompare" | "id.match" | "id.replace" | ... 74 more ...
//   | `tags[${number}]`

type GoodFormPath = FixedFormPath<ExampleData>;
// type GoodFormPath = "id" | "message" | "date" | "user" | "tags" | "user.id" | "user.name" | `tags[${number}]`

/**
 * Example 2: Incompatible with Branded Types
 */
import { FormPathLeaves } from "sveltekit-superforms";
import { FormPathLeaves as FixedFormPathLeaves } from "./fixed";

// When using branded types, the helpers are unable to get the exact path, because branded types
// are both primitive and objects. You can even use the branded type to filter it.

type BadLeaves = FormPathLeaves<ExampleData>;
// type BadLeaves = "message" | "date" | "id.length" | "user.id.length" | "user.name" | `tags[${number}]`

type GoodLeaves = FixedFormPathLeaves<ExampleData>;
// type GoodLeaves = "id" | "message" | "date" | "user.id" | "user.name" | `tags[${number}]`

type IdLeaves = FixedFormPathLeaves<ExampleData, Id>;
// type IdLeaves = "id" | "user.id"
```