### PR TITLE
Migrate valibot to v0.31.0. Fixes #432

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
 		"joi": "^17.13.1",
 		"superstruct": "^1.0.4",
 		"svelte": "3.x || 4.x || >=5.0.0-next.51",
-		"valibot": ">=0.28.1 <=0.30.0",
+		"valibot": ">=0.31.0 <=0.32.0",
 		"yup": "^1.4.0",
 		"zod": "^3.23.8"
 	},
@@ -145,7 +145,7 @@
 	},
 	"optionalDependencies": {
 		"@exodus/schemasafe": "^1.3.0",
-		"@gcornut/valibot-json-schema": "^0.0.27",
+		"@gcornut/valibot-json-schema": "^0.31.0",
 		"@sinclair/typebox": "^0.32.30",
 		"@sodaru/yup-to-json-schema": "^2.0.1",
 		"@vinejs/vine": "^1.8.0",
@@ -153,7 +153,7 @@
 		"joi": "^17.13.1",
 		"json-schema-to-ts": "^3.1.0",
 		"superstruct": "^1.0.4",
-		"valibot": "^0.30.0",
+		"valibot": "^0.31.0",
 		"yup": "^1.4.0",
 		"zod": "^3.23.8",
 		"zod-to-json-schema": "^3.23.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,11 +25,11 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       '@gcornut/valibot-json-schema':
-        specifier: ^0.0.27
-        version: 0.0.27(@types/json-schema@7.0.15)(esbuild-runner@2.2.2(esbuild@0.20.2))(esbuild@0.20.2)(valibot@0.30.0)
+        specifier: ^0.31.0
+        version: 0.31.0
       '@sinclair/typebox':
         specifier: ^0.32.30
-        version: 0.32.30
+        version: 0.32.31
       '@sodaru/yup-to-json-schema':
         specifier: ^2.0.1
         version: 2.0.1
@@ -49,8 +49,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
       valibot:
-        specifier: ^0.30.0
-        version: 0.30.0
+        specifier: ^0.31.0
+        version: 0.31.0
       yup:
         specifier: ^1.4.0
         version: 1.4.0
@@ -164,8 +164,8 @@ packages:
   '@arktype/util@0.0.45':
     resolution: {integrity: sha512-WPzoElBZK1NxYzT8PnoNsnulohgRU7PRKkJUoqeGvuFqP/Egv7tRNnvcJCE0MboHUnWaPTy/5Psjm/4iOvbWiw==}
 
-  '@babel/runtime@7.24.5':
-    resolution: {integrity: sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==}
+  '@babel/runtime@7.24.6':
+    resolution: {integrity: sha512-Ja18XcETdEl5mzzACGd+DKgaGJzPTCow7EglgwTmHdwokzDFYh/MHua6lU6DV/hjF2IaOJ4oX2nqnjG7RElKOw==}
     engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.20.2':
@@ -327,14 +327,9 @@ packages:
   '@exodus/schemasafe@1.3.0':
     resolution: {integrity: sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==}
 
-  '@gcornut/valibot-json-schema@0.0.27':
-    resolution: {integrity: sha512-xcMaUStVgQzPrK3d7PuLFbQ+3qSp6LzaLExAm52E3FKmUfjQa7Sw5cDK6Hfu/8WT0yfGsuSCuJ5uT1sosjR9Qg==}
+  '@gcornut/valibot-json-schema@0.31.0':
+    resolution: {integrity: sha512-3xGptCurm23e7nuPQkdrE5rEs1FeTPHhAUsBuwwqG4/YeZLwJOoYZv+fmsppUEfo5y9lzUwNQrNqLS/q7HMc7g==}
     hasBin: true
-    peerDependencies:
-      '@types/json-schema': '>= 7.0.14'
-      esbuild: '>= 0.18.20'
-      esbuild-runner: '>= 2.2.2'
-      valibot: '>= 0.21.0'
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -490,8 +485,8 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
-  '@sinclair/typebox@0.32.30':
-    resolution: {integrity: sha512-IYK1H0k2sHVB2GjzBK2DXBErhex45GoLuPdgn8lNw5t0+5elIuhpixOMPobFyq6kE0AGIBa4+76Ph4enco0q2Q==}
+  '@sinclair/typebox@0.32.31':
+    resolution: {integrity: sha512-rYB0tgGHawpom3ZwwsGidvI0NI+W/rRHu1dyyO1KlIoH8iMdg3esSnYQxQtyJ8eflhqxmzEV7Nu8zT4JY7CHKw==}
 
   '@sodaru/yup-to-json-schema@2.0.1':
     resolution: {integrity: sha512-lWb0Wiz8KZ9ip/dY1eUqt7fhTPmL24p6Hmv5Fd9pzlzAdw/YNcWZr+tiCT4oZ4Zyxzi9+1X4zv82o7jYvcFxYA==}
@@ -758,7 +753,7 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
 
   confbox@0.1.7:
     resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
@@ -980,10 +975,12 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -1037,6 +1034,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -1322,8 +1320,8 @@ packages:
     peerDependencies:
       postcss: ^8.4.29
 
-  postcss-selector-parser@6.0.16:
-    resolution: {integrity: sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==}
+  postcss-selector-parser@6.1.0:
+    resolution: {integrity: sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==}
     engines: {node: '>=4'}
 
   postcss@8.4.38:
@@ -1384,10 +1382,12 @@ packages:
 
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rollup@4.18.0:
@@ -1669,8 +1669,8 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
-  valibot@0.30.0:
-    resolution: {integrity: sha512-5POBdbSkM+3nvJ6ZlyQHsggisfRtyT4tVTo1EIIShs6qCdXJnyWU5TJ68vr8iTg5zpOLjXLRiBqNx+9zwZz/rA==}
+  valibot@0.31.0:
+    resolution: {integrity: sha512-bleS8aVFpRGTUgbMoXzsRJhpxJGiZ3MG1nuNSORuDvio+sI1EyT1+lQHg+77Pfnlxz+25Uj5HiwdaklcDcYdiQ==}
 
   validator@13.12.0:
     resolution: {integrity: sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==}
@@ -1804,7 +1804,7 @@ snapshots:
   '@arktype/util@0.0.45':
     optional: true
 
-  '@babel/runtime@7.24.5':
+  '@babel/runtime@7.24.6':
     dependencies:
       regenerator-runtime: 0.14.1
     optional: true
@@ -1904,12 +1904,13 @@ snapshots:
   '@exodus/schemasafe@1.3.0':
     optional: true
 
-  '@gcornut/valibot-json-schema@0.0.27(@types/json-schema@7.0.15)(esbuild-runner@2.2.2(esbuild@0.20.2))(esbuild@0.20.2)(valibot@0.30.0)':
+  '@gcornut/valibot-json-schema@0.31.0':
     dependencies:
+      valibot: 0.31.0
+    optionalDependencies:
       '@types/json-schema': 7.0.15
       esbuild: 0.20.2
       esbuild-runner: 2.2.2(esbuild@0.20.2)
-      valibot: 0.30.0
     optional: true
 
   '@hapi/hoek@9.3.0':
@@ -2033,7 +2034,7 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
-  '@sinclair/typebox@0.32.30':
+  '@sinclair/typebox@0.32.31':
     optional: true
 
   '@sodaru/yup-to-json-schema@2.0.1':
@@ -2479,7 +2480,7 @@ snapshots:
       postcss: 8.4.38
       postcss-load-config: 3.1.4(postcss@8.4.38)
       postcss-safe-parser: 6.0.0(postcss@8.4.38)
-      postcss-selector-parser: 6.0.16
+      postcss-selector-parser: 6.1.0
       semver: 7.6.2
       svelte-eslint-parser: 0.36.0(svelte@5.0.0-next.137)
     optionalDependencies:
@@ -2742,7 +2743,7 @@ snapshots:
 
   json-schema-to-ts@3.1.0:
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.6
       ts-algebra: 2.0.0
     optional: true
 
@@ -2950,7 +2951,7 @@ snapshots:
     dependencies:
       postcss: 8.4.38
 
-  postcss-selector-parser@6.0.16:
+  postcss-selector-parser@6.1.0:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
@@ -3278,7 +3279,7 @@ snapshots:
 
   uuid@9.0.1: {}
 
-  valibot@0.30.0:
+  valibot@0.31.0:
     optional: true
 
   validator@13.12.0:

--- a/src/lib/adapters/typeSchema.ts
+++ b/src/lib/adapters/typeSchema.ts
@@ -1,7 +1,12 @@
 import type { TSchema, Static as Static$1 } from '@sinclair/typebox';
 import type { Type } from 'arktype';
 import type { AnySchema } from 'joi';
-import type { BaseSchema, BaseSchemaAsync, Input, Output } from 'valibot';
+import type {
+	GenericSchema,
+	GenericSchemaAsync,
+	InferInput as Input,
+	InferOutput as Output
+} from 'valibot';
 import type { Schema as Schema$2, InferType } from 'yup';
 import type { ZodSchema, input, output } from 'zod';
 import type { SchemaTypes, Infer as VineInfer } from '@vinejs/vine/types';
@@ -47,7 +52,7 @@ type InferSchema<TResolver extends Resolver> = TResolver['base'];
 
 type ValidationIssue = {
 	message: string;
-	path?: Array<string | number | symbol>;
+	path?: Array<string | number | symbol | unknown>;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -94,9 +99,11 @@ interface TypeBoxResolver extends Resolver {
 }
 
 interface ValibotResolver extends Resolver {
-	base: BaseSchema | BaseSchemaAsync;
-	input: this['schema'] extends BaseSchema | BaseSchemaAsync ? Input<this['schema']> : never;
-	output: this['schema'] extends BaseSchema | BaseSchemaAsync ? Output<this['schema']> : never;
+	base: GenericSchema | GenericSchemaAsync;
+	input: this['schema'] extends GenericSchema | GenericSchemaAsync ? Input<this['schema']> : never;
+	output: this['schema'] extends GenericSchema | GenericSchemaAsync
+		? Output<this['schema']>
+		: never;
 }
 
 interface YupResolver extends Resolver {

--- a/src/routes/(v2)/v2/issue-366/schema.ts
+++ b/src/routes/(v2)/v2/issue-366/schema.ts
@@ -4,8 +4,9 @@ import {
 	object,
 	boolean,
 	minLength,
-	toTrimmed,
+	trim,
 	picklist,
+	pipe,
 	literal,
 	date
 } from 'valibot';
@@ -13,13 +14,14 @@ import {
 const roleOptions = ['USER', 'PREMIUM', 'ADMIN'] as const;
 
 export const userSchema = object({
-	firstName: string([toTrimmed(), minLength(1, 'Please enter your first name.')]),
-	lastName: string([toTrimmed(), minLength(1, 'Please enter your last name.')]),
-	email: string([
-		toTrimmed(),
+	firstName: pipe(string(), trim(), minLength(1, 'Please enter your first name.')),
+	lastName: pipe(string(), trim(), minLength(1, 'Please enter your last name.')),
+	email: pipe(
+		string(),
+		trim(),
 		email('The email address is not valid.'),
 		minLength(1, 'An email address is required.')
-	]),
+	),
 	role: picklist(roleOptions, 'You must have a role.'),
 	verified: boolean(),
 	terms: literal(true, 'You must accept the terms and privacy policy.'),
@@ -29,11 +31,12 @@ export const userSchema = object({
 });
 
 export const emailSchema = object({
-	email: string([
-		toTrimmed(),
+	email: pipe(
+		string(),
+		trim(),
 		email('The email address is not valid.'),
 		minLength(1, 'An email address is required.')
-	])
+	)
 });
 
 export type UserSchema = typeof userSchema;

--- a/src/routes/(v2)/v2/nested-validation-valibot/schema.ts
+++ b/src/routes/(v2)/v2/nested-validation-valibot/schema.ts
@@ -1,4 +1,4 @@
-import { array, integer, minLength, minValue, number, object, string } from 'valibot';
+import { array, integer, minLength, minValue, number, object, pipe, string } from 'valibot';
 
 /*
 export const schema2 = z
@@ -15,11 +15,11 @@ export const schema2 = z
 */
 
 export const schema = object({
-	name: string([minLength(1, 'Name is too short')]),
+	name: pipe(string(), minLength(1, 'Name is too short')),
 	tags: array(
 		object({
-			id: number([integer(), minValue(3)]),
-			name: string([minLength(2)])
+			id: pipe(number(), integer(), minValue(3)),
+			name: pipe(string(), minLength(2))
 		})
 	)
 });

--- a/src/routes/(v2)/v2/spa-action-2/classify/schema.ts
+++ b/src/routes/(v2)/v2/spa-action-2/classify/schema.ts
@@ -1,6 +1,6 @@
 import * as v from 'valibot';
 
 export const classifySchema = v.object({
-	id: v.number([v.minValue(1)]),
+	id: v.pipe(v.number(), v.minValue(1)),
 	name: v.string()
 });

--- a/src/routes/(v2)/v2/spa-clearonsubmit/schema.ts
+++ b/src/routes/(v2)/v2/spa-clearonsubmit/schema.ts
@@ -1,6 +1,6 @@
-import { object, string, email, minLength } from 'valibot';
+import { object, string, email, minLength, pipe } from 'valibot';
 
 export const schema = object({
-	name: string([minLength(2)]),
-	email: string([email()])
+	name: pipe(string(), minLength(2)),
+	email: pipe(string(), email())
 });

--- a/src/routes/(v2)/v2/valibot-dates/schema.ts
+++ b/src/routes/(v2)/v2/valibot-dates/schema.ts
@@ -1,6 +1,6 @@
-import { date, minLength, object, string } from 'valibot';
+import { date, minLength, object, pipe, string } from 'valibot';
 
 export const schema = object({
 	date: date(),
-	missing: string([minLength(1)])
+	missing: pipe(string(), minLength(1))
 });

--- a/src/routes/(v2)/v2/valibot-nullable/schema.ts
+++ b/src/routes/(v2)/v2/valibot-nullable/schema.ts
@@ -1,6 +1,6 @@
-import { object, string, minLength, email, nullable } from 'valibot';
+import { object, string, minLength, email, nullable, pipe } from 'valibot';
 
 export const schema = object({
-	name: nullable(string([minLength(1)])),
-	email: string([email()])
+	name: nullable(pipe(string(), minLength(1))),
+	email: pipe(string(), email())
 });

--- a/src/tests/formData.test.ts
+++ b/src/tests/formData.test.ts
@@ -65,7 +65,7 @@ describe('FormData parsing', () => {
 
 	it('should throw an error if literals are different from the other types', () => {
 		const schema = v.object({
-			urltest: v.union([v.literal(123), v.string([v.startsWith('https://')])])
+			urltest: v.union([v.literal(123), v.pipe(v.string(), v.startsWith('https://'))])
 		});
 
 		expect(() => valibot(schema)).toThrowError(SchemaError);
@@ -73,7 +73,7 @@ describe('FormData parsing', () => {
 
 	it('should treat literals as their typeof type', () => {
 		const schema = v.object({
-			urltest: v.union([v.literal(''), v.string([v.startsWith('https://')])])
+			urltest: v.union([v.literal(''), v.pipe(v.string(), v.startsWith('https://'))])
 		});
 
 		expect(valibot(schema).defaults.urltest).toBe('');

--- a/src/tests/legacy/paths.test-d.ts
+++ b/src/tests/legacy/paths.test-d.ts
@@ -385,7 +385,7 @@ test('FormPath with any type', () => {
 test('Schemas with built-in objects', () => {
 	const schema = v.object({
 		id: v.nullish(v.string(), ''),
-		name: v.string([v.minLength(1)]),
+		name: v.pipe(v.string(), v.minLength(1)),
 		date: v.date()
 	});
 

--- a/src/tests/superValidate.test.ts
+++ b/src/tests/superValidate.test.ts
@@ -330,11 +330,11 @@ describe('Arktype', () => {
 describe('Valibot', () => {
 	const schema = v.object({
 		name: v.optional(v.string(), 'Unknown'),
-		email: v.string([v.email()]),
-		tags: v.array(v.string([v.minLength(2)]), [v.minLength(3)]),
-		score: v.number([v.integer(), v.minValue(0)]),
+		email: v.pipe(v.string(), v.email()),
+		tags: v.pipe(v.array(v.pipe(v.string(), v.minLength(2))), v.minLength(3)),
+		score: v.pipe(v.number(), v.integer(), v.minValue(0)),
 		date: v.optional(v.date()),
-		nospace: v.optional(v.string([v.regex(nospacePattern)])),
+		nospace: v.optional(v.pipe(v.string(), v.regex(nospacePattern))),
 		extra: v.nullable(v.string())
 	});
 
@@ -377,11 +377,12 @@ describe('Valibot', () => {
 
 	it('should handle non-JSON Schema validators by returning any', async () => {
 		const schema = v.object({
-			file: v.instance(File, [
+			file: v.pipe(
+				v.instance(File),
 				v.mimeType(['image/jpeg', 'image/png']),
 				v.maxSize(1024 * 1024 * 10)
-			]),
-			size: v.special<`${number}px`>((val) =>
+			),
+			size: v.custom<`${number}px`>((val) =>
 				typeof val === 'string' ? /^\d+px$/.test(val) : false
 			)
 		});
@@ -776,7 +777,10 @@ describe('Schema In/Out transformations', () => {
 
 	it('does not fully work with Valibot', async () => {
 		const schema = v.object({
-			len: v.transform(v.string(), (s) => s.length)
+			len: v.pipe(
+				v.string(),
+				v.transform((s) => s.length)
+			)
 		});
 
 		// @ts-expect-error Using schema Out type as In - Not allowed


### PR DESCRIPTION
Waiting on [valibot-json-schema](https://github.com/gcornut/valibot-json-schema/pull/57) to merge. Will be a draft PR till then.

Followed [this guide](https://valibot.dev/guides/migrate-from-v0.30.0/) using the [codemod](https://codemod.com/registry/valibot-0-30-0).
All unit tests pass.
