### PR TITLE
fix(stringPath): ensure Type passed to `FormPathArrays` is Array when filtering

### DIFF
--- a/src/lib/stringPath.ts
+++ b/src/lib/stringPath.ts
@@ -45,7 +45,15 @@ export type FormPathLeavesWithErrors<T extends object, Type = any> = string &
  * List all arrays in an object as string accessors.
  */
 export type FormPathArrays<T extends object, Type = any> = string &
-	StringPath<T, { filter: 'arrays'; objAppend: never; path: ''; type: Type }>;
+	StringPath<
+		T,
+		{
+			filter: 'arrays';
+			objAppend: never;
+			path: '';
+			type: Type extends Array<any> ? Type : Array<Type>;
+		}
+	>;
 
 type Concat<
 	Path extends string,
@@ -83,95 +91,95 @@ type StringPath<
 		type: never;
 	}
 > = T extends (infer U)[]
-		?
-				| If<Options, 'objAppend', string, Concat<Options['path'], Options['objAppend']>, never, T>
-				| If<Options, 'filter', 'arrays' | 'all', Options['path'], never, T>
-				| (NonNullable<U> extends DictOrArray
-						? StringPath<
-								NonNullable<U>,
-								{
-									filter: Options['filter'];
-									objAppend: Options['objAppend'];
-									path: `${Options['path']}[${number}]`;
-									type: Options['type'];
-								}
-							>
-						: If<Options, 'filter', 'leaves' | 'all', `${Options['path']}[${number}]`, never, T>)
-		: {
-				[K in Extract<AllKeys<T>, string>]: NonNullable<T[K]> extends DictOrArray
+	?
+			| If<Options, 'objAppend', string, Concat<Options['path'], Options['objAppend']>, never, T>
+			| If<Options, 'filter', 'arrays' | 'all', Options['path'], never, T>
+			| (NonNullable<U> extends DictOrArray
+					? StringPath<
+							NonNullable<U>,
+							{
+								filter: Options['filter'];
+								objAppend: Options['objAppend'];
+								path: `${Options['path']}[${number}]`;
+								type: Options['type'];
+							}
+						>
+					: If<Options, 'filter', 'leaves' | 'all', `${Options['path']}[${number}]`, never, T>)
+	: {
+			[K in Extract<AllKeys<T>, string>]: NonNullable<T[K]> extends DictOrArray
+				?
+						| If<
+								Options,
+								'objAppend',
+								string,
+								Concat<Options['path'], Options['objAppend']>,
+								never,
+								T[K]
+						  >
+						| NonNullable<T[K]> extends (infer U)[]
 					?
-							| If<
-									Options,
-									'objAppend',
-									string,
-									Concat<Options['path'], Options['objAppend']>,
-									never,
-									T[K]
-							  >
-							| NonNullable<T[K]> extends (infer U)[]
-						?
-								| If<Options, 'filter', 'arrays' | 'all', Concat<Options['path'], K>, never, T[K]>
-								| (NonNullable<U> extends unknown[]
-										? If<
-												Options,
-												'filter',
-												'arrays' | 'all',
-												Concat<Options['path'], `${K}[${number}]`>,
-												never,
-												T[K]
-											>
-										: NonNullable<U> extends DictOrArray
-											? IsAny<T[K]> extends true
-												? Concat<Options['path'], `${K}[${number}]`>
-												: If<
-														Options,
-														'filter',
-														'all',
-														Concat<Options['path'], `${K}[${number}]`>,
-														never,
-														U
-													>
+							| If<Options, 'filter', 'arrays' | 'all', Concat<Options['path'], K>, never, T[K]>
+							| (NonNullable<U> extends unknown[]
+									? If<
+											Options,
+											'filter',
+											'arrays' | 'all',
+											Concat<Options['path'], `${K}[${number}]`>,
+											never,
+											T[K]
+										>
+									: NonNullable<U> extends DictOrArray
+										? IsAny<T[K]> extends true
+											? Concat<Options['path'], `${K}[${number}]`>
 											: If<
 													Options,
 													'filter',
-													'leaves' | 'all',
+													'all',
 													Concat<Options['path'], `${K}[${number}]`>,
 													never,
 													U
-												>)
-								| (NonNullable<U> extends DictOrArray
-										? StringPath<
-												NonNullable<U>,
-												{
-													filter: Options['filter'];
-													objAppend: Options['objAppend'];
-													path: Concat<Options['path'], `${K}[${number}]`>;
-													type: Options['type'];
-												}
-											>
-										: never)
-						: IsAny<T[K]> extends true
-							? Concat<Options['path'], K>
-							:
-									| If<
-											Options,
-											'filter',
-											'all',
-											Concat<Options['path'], K>,
-											unknown extends T[K] ? Concat<Options['path'], K> : never,
-											T[K]
-									  >
-									| StringPath<
-											NonNullable<T[K]>,
+												>
+										: If<
+												Options,
+												'filter',
+												'leaves' | 'all',
+												Concat<Options['path'], `${K}[${number}]`>,
+												never,
+												U
+											>)
+							| (NonNullable<U> extends DictOrArray
+									? StringPath<
+											NonNullable<U>,
 											{
 												filter: Options['filter'];
 												objAppend: Options['objAppend'];
-												path: Concat<Options['path'], K>;
+												path: Concat<Options['path'], `${K}[${number}]`>;
 												type: Options['type'];
 											}
-									  >
-					: If<Options, 'filter', 'leaves' | 'all', Concat<Options['path'], K>, never, T[K]>;
-			}[Extract<AllKeys<T>, string>];
+										>
+									: never)
+					: IsAny<T[K]> extends true
+						? Concat<Options['path'], K>
+						:
+								| If<
+										Options,
+										'filter',
+										'all',
+										Concat<Options['path'], K>,
+										unknown extends T[K] ? Concat<Options['path'], K> : never,
+										T[K]
+								  >
+								| StringPath<
+										NonNullable<T[K]>,
+										{
+											filter: Options['filter'];
+											objAppend: Options['objAppend'];
+											path: Concat<Options['path'], K>;
+											type: Options['type'];
+										}
+								  >
+				: If<Options, 'filter', 'leaves' | 'all', Concat<Options['path'], K>, never, T[K]>;
+		}[Extract<AllKeys<T>, string>];
 
 export type FormPathType<T, P extends string> = P extends keyof T
 	? T[P]

--- a/src/routes/(v2)/v2/issue-464/+page.server.ts
+++ b/src/routes/(v2)/v2/issue-464/+page.server.ts
@@ -1,0 +1,8 @@
+import { zod } from '$lib/adapters/zod.js';
+import { superValidate } from '$lib/index.js';
+import { schema } from './schema.js';
+
+export const load = async () => {
+	const form = await superValidate(zod(schema));
+	return { form };
+};

--- a/src/routes/(v2)/v2/issue-464/+page.svelte
+++ b/src/routes/(v2)/v2/issue-464/+page.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import { zod } from '$lib/adapters/zod.js';
+	import SuperDebug, { superForm } from '$lib/index.js';
+	import CheckboxGroup from './CheckboxGroup.svelte';
+	import { schema } from './schema.js';
+
+	export let data;
+
+	const form = superForm(data.form, { validators: zod(schema) });
+	const { form: formValues, enhance } = form;
+</script>
+
+<SuperDebug data={$formValues} />
+
+<h3>Making FormPathArrays handle single value</h3>
+
+<form method="POST" use:enhance>
+	<CheckboxGroup
+		{form}
+		label="test"
+		field="testArray"
+		options={[
+			{ label: 'Option 1', value: 1 },
+			{ label: 'Option 2', value: 2 }
+		]}
+	/>
+
+	<button>Submit</button>
+</form>
+
+<hr />
+<p>
+	💥 <a target="_blank" href="https://superforms.rocks">Created with Superforms for SvelteKit</a> 💥
+</p>
+
+<style>
+	.invalid {
+		color: red;
+	}
+
+	.status {
+		color: white;
+		padding: 4px;
+		padding-left: 8px;
+		border-radius: 2px;
+		font-weight: 500;
+	}
+
+	.status.success {
+		background-color: seagreen;
+	}
+
+	.status.error {
+		background-color: #ff2a02;
+	}
+
+	input {
+		background-color: #ddd;
+	}
+
+	a {
+		text-decoration: underline;
+	}
+
+	hr {
+		margin-top: 4rem;
+	}
+
+	form {
+		padding-top: 1rem;
+		padding-bottom: 1rem;
+	}
+</style>

--- a/src/routes/(v2)/v2/issue-464/CheckboxGroup.svelte
+++ b/src/routes/(v2)/v2/issue-464/CheckboxGroup.svelte
@@ -1,0 +1,35 @@
+<script lang="ts" generics="T extends Record<string, unknown>, TItem">
+	import { type SuperForm, arrayProxy, type FormPathArrays } from '$lib/index.js';
+
+	export let form: SuperForm<T>;
+	export let field: FormPathArrays<T, TItem>;
+
+	const { values: rawValue, errors } = arrayProxy(form, field);
+
+	export let options: Array<{ label: string; value: TItem }>;
+	export let label: string | undefined = undefined;
+</script>
+
+<fieldset>
+	{#if $$slots.default || label}
+		<legend><slot>{label}</slot></legend>
+	{/if}
+
+	{#each options as { label, value } (value)}
+		<label class="">
+			<div class="flex items-center gap-x-2">
+				<input
+					name={field}
+					class="checkbox"
+					class:input-error={!!$errors}
+					type="checkbox"
+					bind:group={$rawValue}
+					{value}
+				/>
+				<p>{label}</p>
+			</div>
+		</label>
+	{:else}
+		<p>Geen opties</p>
+	{/each}
+</fieldset>

--- a/src/routes/(v2)/v2/issue-464/schema.ts
+++ b/src/routes/(v2)/v2/issue-464/schema.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const schema = z.object({
+	testArray: z.number().array()
+});


### PR DESCRIPTION
fixes #464 

Previously, `FormPathArrays` accepted any type, but only worked when an Array was passed. Now, if the passed value is not an Array, it will be converted to an array to ensure consistent path filtering. 