### PR TITLE
feat!: migration from @effect/schema to effect monorepo package

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
 		"!dist/**/*.spec.*"
 	],
 	"peerDependencies": {
-		"@effect/schema": "^0.75.3",
 		"@exodus/schemasafe": "^1.3.0",
 		"@sinclair/typebox": "^0.34.9",
 		"@sveltejs/kit": "1.x || 2.x",
@@ -110,7 +109,7 @@
 		"@vinejs/vine": "^1.8.0 || ^2.0.0",
 		"arktype": ">=2.0.0-rc.23",
 		"class-validator": "^0.14.1",
-		"effect": "^3.8.2",
+		"effect": "^3.10.0",
 		"joi": "^17.13.1",
 		"superstruct": "^2.0.2",
 		"svelte": "3.x || 4.x || >=5.0.0-next.51",
@@ -168,7 +167,7 @@
 		"@vinejs/vine": "^2.0.0",
 		"arktype": "^2.0.0-rc.23",
 		"class-validator": "^0.14.1",
-		"effect": "^3.9.1",
+		"effect": "^3.10.0",
 		"joi": "^17.13.3",
 		"json-schema-to-ts": "^3.1.1",
 		"superstruct": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
     optionalDependencies:
       '@effect/schema':
         specifier: ^0.75.3
-        version: 0.75.3(effect@3.9.1)
+        version: 0.75.3(effect@3.10.0)
       '@exodus/schemasafe':
         specifier: ^1.3.0
         version: 1.3.0
@@ -46,8 +46,8 @@ importers:
         specifier: ^0.14.1
         version: 0.14.1
       effect:
-        specifier: ^3.9.1
-        version: 3.9.1
+        specifier: ^3.10.0
+        version: 3.10.0
       joi:
         specifier: ^17.13.3
         version: 17.13.3
@@ -1016,8 +1016,8 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
-  effect@3.9.1:
-    resolution: {integrity: sha512-dxd+eiCqxOriBM12EQ6uIjn3cJpKIP7DfqafWTVEb45aMO157iEeDcO09SEdVSAy/OqpFlRF+4Lx7Hei1ipvOA==}
+  effect@3.10.0:
+    resolution: {integrity: sha512-J9rsJBXNHZxklJTbHriY8D9wIHhmvXDamExW4pPZ2kPNZ+XRfstXeHBqpXAIK+B42ASVbuDswAXyup5WHWK6jg==}
 
   es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
@@ -2037,9 +2037,9 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
-  '@effect/schema@0.75.3(effect@3.9.1)':
+  '@effect/schema@0.75.3(effect@3.10.0)':
     dependencies:
-      effect: 3.9.1
+      effect: 3.10.0
       fast-check: 3.22.0
     optional: true
 
@@ -2745,7 +2745,9 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  effect@3.9.1:
+  effect@3.10.0:
+    dependencies:
+      fast-check: 3.22.0
     optional: true
 
   es6-promise@3.3.1: {}

--- a/src/lib/adapters/effect.ts
+++ b/src/lib/adapters/effect.ts
@@ -1,5 +1,6 @@
-import { Schema, JSONSchema, ArrayFormatter } from '@effect/schema';
-import { Either } from 'effect';
+import { Schema, JSONSchema, Either } from 'effect';
+import type { ParseOptions } from 'effect/SchemaAST';
+import { ArrayFormatter } from 'effect/ParseResult';
 import type { JSONSchema as TJSONSchema } from '../jsonSchema/index.js';
 import {
 	createAdapter,
@@ -10,7 +11,6 @@ import {
 	type ValidationAdapter,
 	type ValidationResult
 } from './adapters.js';
-import type { ParseOptions } from '@effect/schema/AST';
 import { memoize } from '$lib/memoize.js';
 
 export const effectToJSONSchema = <A, I>(schema: Schema.Schema<A, I>) => {

--- a/src/lib/adapters/typeSchema.ts
+++ b/src/lib/adapters/typeSchema.ts
@@ -18,12 +18,12 @@ import type { ZodSchema, input, output } from 'zod';
 import type { SchemaTypes, Infer as VineInfer } from '@vinejs/vine/types';
 import type { FromSchema, JSONSchema } from 'json-schema-to-ts';
 import type { Struct, Infer as Infer$2 } from 'superstruct';
-import type { Schema as Schema$1 } from '@effect/schema/Schema';
+import type { Schema as Schema$1 } from 'effect';
 
 /*
 import type { SchemaObject } from 'ajv';
 import type { Type as Type$1 } from '@deepkit/type';
-import type { Schema as Schema$1 } from '@effect/schema/Schema';
+import type { Schema as Schema$1 } from 'effect';
 import type { Any, OutputOf, TypeOf } from 'io-ts';
 import type { Predicate, Infer as Infer$1 } from 'ow';
 import type { Runtype, Static } from 'runtypes';
@@ -159,11 +159,15 @@ interface SuperstructResolver extends Resolver {
 
 interface EffectResolver extends Resolver {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	base: Schema$1<any>;
+	base: Schema$1.Schema<any>;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	input: this['schema'] extends Schema$1<any> ? Schema$1.Encoded<this['schema']> : never;
+	input: this['schema'] extends Schema$1.Schema<any>
+		? Schema$1.Schema.Encoded<this['schema']>
+		: never;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	output: this['schema'] extends Schema$1<any> ? Schema$1.Type<this['schema']> : never;
+	output: this['schema'] extends Schema$1.Schema<any>
+		? Schema$1.Schema.Type<this['schema']>
+		: never;
 }
 
 /*

--- a/src/routes/(v2)/v2/effect/+page.svelte
+++ b/src/routes/(v2)/v2/effect/+page.svelte
@@ -1,15 +1,11 @@
 <script lang="ts">
 	import { superForm } from '$lib/client/index.js';
 	import SuperDebug from '$lib/client/SuperDebug.svelte';
-	//import { zod } from '$lib/adapters/zod.js'
-	//import { schema } from './schema.js';
 
 	export let data;
 
 	const { form, errors, tainted, message, enhance } = superForm(data.form, {
 		taintedMessage: false
-		//dataType: 'json',
-		//validators: zod(schema)
 	});
 </script>
 

--- a/src/routes/(v2)/v2/effect/schema.ts
+++ b/src/routes/(v2)/v2/effect/schema.ts
@@ -1,4 +1,4 @@
-import { Schema } from '@effect/schema';
+import { Schema } from 'effect';
 
 const emailRegex = /^[^@]+@[^@]+\.[^@]+$/;
 

--- a/src/tests/superValidate.test.ts
+++ b/src/tests/superValidate.test.ts
@@ -79,7 +79,7 @@ import {
 import { schemasafe } from '$lib/adapters/schemasafe.js';
 
 import { effect } from '$lib/adapters/effect.js';
-import { Schema } from '@effect/schema';
+import { Schema } from 'effect';
 
 import { traversePath } from '$lib/traversal.js';
 import { splitPath } from '$lib/stringPath.js';


### PR DESCRIPTION
I have created a PR for the following Issue as I have not seen any progress on it.
If it has already been addressed, I will close it.

close https://github.com/ciscoheat/sveltekit-superforms/issues/497

# Changes

- Delete @effect/schema
- Upgrade @effect package
- Correction of import path

Local testing was successful.