### PR TITLE
fix: Handle int64 as BigInt from jsonSchema

### DIFF
--- a/src/lib/formData.ts
+++ b/src/lib/formData.ts
@@ -297,6 +297,11 @@ function parseFormDataEntry(
 		);
 	}
 
+        // Special case for integer with format int64
+        if (type == 'integer' && info.schema?.format === 'int64') {
+                return BigInt(value ?? '.');
+        }
+
 	switch (type) {
 		case 'string':
 		case 'any':


### PR DESCRIPTION
`z.bigint()` will be interpreted by jsonSchema as `{ type: 'integer', format: 'int64' }`. 
Which means that `parseFormDataEntry` will parseInt during the switch(type). For a value of "337224005901615104", it will return "337224005901615100" instead, and superforms will return a 400 with "Expected bigint, received number".

This check earlier if it's an integer with format int64 and if so return it as a BigInt.

I'm not sure if this should be done earlier though, in jsonSchema file directly during `schemaTypes` call. Let me know what you think. 