### PR TITLE
Support Zod 3.24, simplify Zod resolver, improve type performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
 		"superstruct": "^2.0.2",
 		"valibot": "^1.0.0-beta.3",
 		"yup": "^1.4.0",
-		"zod": "^3.23.8",
+		"zod": "^3.24.0",
 		"zod-to-json-schema": "^3.23.3"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
 		"superstruct": "^2.0.2",
 		"valibot": "^1.0.0-beta.3",
 		"yup": "^1.4.0",
-		"zod": "^3.24.0",
+		"zod": "^3.23.8",
 		"zod-to-json-schema": "^3.23.3"
 	},
 	"dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,11 +64,11 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       zod:
-        specifier: ^3.23.8
-        version: 3.23.8
+        specifier: ^3.24.0
+        version: 3.24.0
       zod-to-json-schema:
         specifier: ^3.23.3
-        version: 3.23.3(zod@3.23.8)
+        version: 3.23.3(zod@3.24.0)
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^3.2.5
@@ -168,7 +168,7 @@ importers:
         version: 1.6.0(@types/node@22.7.4)(sass@1.79.4)
       zod-i18n-map:
         specifier: ^2.27.0
-        version: 2.27.0(i18next@23.15.1)(zod@3.23.8)
+        version: 2.27.0(i18next@23.15.1)(zod@3.24.0)
 
 packages:
 
@@ -2015,8 +2015,8 @@ packages:
     peerDependencies:
       zod: ^3.23.3
 
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+  zod@3.24.0:
+    resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
 
 snapshots:
 
@@ -3752,14 +3752,14 @@ snapshots:
 
   zimmerframe@1.1.2: {}
 
-  zod-i18n-map@2.27.0(i18next@23.15.1)(zod@3.23.8):
+  zod-i18n-map@2.27.0(i18next@23.15.1)(zod@3.24.0):
     dependencies:
       i18next: 23.15.1
-      zod: 3.23.8
+      zod: 3.24.0
 
-  zod-to-json-schema@3.23.3(zod@3.23.8):
+  zod-to-json-schema@3.23.3(zod@3.24.0):
     dependencies:
-      zod: 3.23.8
+      zod: 3.24.0
     optional: true
 
-  zod@3.23.8: {}
+  zod@3.24.0: {}

--- a/src/lib/adapters/adapters.ts
+++ b/src/lib/adapters/adapters.ts
@@ -16,8 +16,12 @@ import { simpleSchema } from './simple-schema/index.js';
 
 export type { Schema, ValidationIssue, ValidationResult } from './typeSchema.js';
 
-export type Infer<T extends Schema, K extends keyof Registry = keyof Registry> = NonNullable<InferSchema<T, K>>;
-export type InferIn<T extends Schema, K extends keyof Registry = keyof Registry> = NonNullable<InferInSchema<T, K>>;
+export type Infer<T extends Schema, K extends keyof Registry = keyof Registry> = NonNullable<
+	InferSchema<T, K>
+>;
+export type InferIn<T extends Schema, K extends keyof Registry = keyof Registry> = NonNullable<
+	InferInSchema<T, K>
+>;
 
 export type ValidationLibrary =
 	| 'arktype'

--- a/src/lib/adapters/adapters.ts
+++ b/src/lib/adapters/adapters.ts
@@ -9,14 +9,15 @@ import type {
 	Schema,
 	ValidationResult,
 	Infer as InferSchema,
-	InferIn as InferInSchema
+	InferIn as InferInSchema,
+	Registry
 } from './typeSchema.js';
 import { simpleSchema } from './simple-schema/index.js';
 
 export type { Schema, ValidationIssue, ValidationResult } from './typeSchema.js';
 
-export type Infer<T extends Schema> = NonNullable<InferSchema<T>>;
-export type InferIn<T extends Schema> = NonNullable<InferInSchema<T>>;
+export type Infer<T extends Schema, K extends keyof Registry = keyof Registry> = NonNullable<InferSchema<T, K>>;
+export type InferIn<T extends Schema, K extends keyof Registry = keyof Registry> = NonNullable<InferInSchema<T, K>>;
 
 export type ValidationLibrary =
 	| 'arktype'

--- a/src/lib/adapters/typeSchema.ts
+++ b/src/lib/adapters/typeSchema.ts
@@ -129,8 +129,8 @@ interface YupResolver extends Resolver {
 
 interface ZodResolver extends Resolver {
 	base: ZodTypeAny;
-	input: this['schema'] extends ZodType<any, any, infer I> ? I : never;
-	output: this['schema'] extends ZodType<infer O, any, any> ? O : never;
+	input: this['schema'] extends ZodTypeAny ? this['schema']['_input'] : never;
+	output: this['schema'] extends ZodTypeAny ? this['schema']['_output'] : never;
 }
 
 interface VineResolver extends Resolver {

--- a/src/lib/adapters/typeSchema.ts
+++ b/src/lib/adapters/typeSchema.ts
@@ -14,7 +14,7 @@ import type {
 	InferOutput as Output
 } from 'valibot';
 import type { Schema as Schema$2, InferType } from 'yup';
-import type { ZodType, ZodTypeAny } from 'zod';
+import type { ZodTypeAny, input, output } from 'zod';
 import type { SchemaTypes, Infer as VineInfer } from '@vinejs/vine/types';
 import type { FromSchema, JSONSchema } from 'json-schema-to-ts';
 import type { Struct, Infer as Infer$2 } from 'superstruct';
@@ -129,8 +129,8 @@ interface YupResolver extends Resolver {
 
 interface ZodResolver extends Resolver {
 	base: ZodTypeAny;
-	input: this['schema'] extends ZodTypeAny ? this['schema']['_input'] : never;
-	output: this['schema'] extends ZodTypeAny ? this['schema']['_output'] : never;
+	input: this['schema'] extends ZodTypeAny ? input<this['schema']> : never;
+	output: this['schema'] extends ZodTypeAny ? output<this['schema']> : never;
 }
 
 interface VineResolver extends Resolver {

--- a/src/lib/adapters/typeSchema.ts
+++ b/src/lib/adapters/typeSchema.ts
@@ -129,8 +129,8 @@ interface YupResolver extends Resolver {
 
 interface ZodResolver extends Resolver {
 	base: ZodTypeAny;
-	input: this['schema'] extends ZodType<any, any, infer I>  ? I : never;
-	output: this['schema'] extends ZodType<infer O, any,any> ? O : never;
+	input: this['schema'] extends ZodType<any, any, infer I> ? I : never;
+	output: this['schema'] extends ZodType<infer O, any, any> ? O : never;
 }
 
 interface VineResolver extends Resolver {

--- a/src/lib/adapters/typeSchema.ts
+++ b/src/lib/adapters/typeSchema.ts
@@ -14,7 +14,7 @@ import type {
 	InferOutput as Output
 } from 'valibot';
 import type { Schema as Schema$2, InferType } from 'yup';
-import type { ZodSchema, input, output } from 'zod';
+import type { ZodType, ZodTypeAny } from 'zod';
 import type { SchemaTypes, Infer as VineInfer } from '@vinejs/vine/types';
 import type { FromSchema, JSONSchema } from 'json-schema-to-ts';
 import type { Struct, Infer as Infer$2 } from 'superstruct';
@@ -128,9 +128,9 @@ interface YupResolver extends Resolver {
 }
 
 interface ZodResolver extends Resolver {
-	base: ZodSchema;
-	input: this['schema'] extends ZodSchema ? input<this['schema']> : never;
-	output: this['schema'] extends ZodSchema ? output<this['schema']> : never;
+	base: ZodTypeAny;
+	input: this['schema'] extends ZodType<any, any, infer I>  ? I : never;
+	output: this['schema'] extends ZodType<infer O, any,any> ? O : never;
 }
 
 interface VineResolver extends Resolver {
@@ -194,8 +194,7 @@ interface RuntypesResolver extends Resolver {
 }
 
 */
-
-type Registry = {
+export type Registry = {
 	arktype: ArkTypeResolver;
 	classvalidator: ClassValidatorResolver;
 	custom: CustomResolver;
@@ -217,15 +216,15 @@ type Registry = {
     */
 };
 
-type Infer<TSchema extends Schema> = UnknownIfNever<
+type Infer<TSchema extends Schema, Keys extends keyof Registry = keyof Registry> = UnknownIfNever<
 	{
-		[K in keyof Registry]: IfDefined<InferOutput<Registry[K], TSchema>>;
-	}[keyof Registry]
+		[K in Keys]: IfDefined<InferOutput<Registry[K], TSchema>>;
+	}[Keys]
 >;
-type InferIn<TSchema extends Schema> = UnknownIfNever<
+type InferIn<TSchema extends Schema, Keys extends keyof Registry = keyof Registry> = UnknownIfNever<
 	{
-		[K in keyof Registry]: IfDefined<InferInput<Registry[K], TSchema>>;
-	}[keyof Registry]
+		[K in Keys]: IfDefined<InferInput<Registry[K], TSchema>>;
+	}[Keys]
 >;
 
 /*

--- a/src/lib/adapters/zod.ts
+++ b/src/lib/adapters/zod.ts
@@ -35,8 +35,6 @@ export type ZodObjectTypes = ZodObjectType;
 
 // left in for compatibility reasons
 export type ZodValidation<T extends ZodObjectTypes = ZodObjectTypes> = T;
-// type asdf = ZodValidation['_output']
-// type asdf2 = ZodValidation['_input']
 
 async function validate<T extends ZodValidation>(
 	schema: T,

--- a/src/lib/adapters/zod.ts
+++ b/src/lib/adapters/zod.ts
@@ -63,8 +63,7 @@ function _zod<T extends ZodValidation>(
 ): ValidationAdapter<Infer<T, 'zod'>, InferIn<T, 'zod'>> {
 	return createAdapter({
 		superFormValidationLibrary: 'zod',
-		async validate(data) {
-			// options?.defaults
+		validate: async (data) => {
 			return validate(schema, data, options?.errorMap);
 		},
 		jsonSchema: options?.jsonSchema ?? zodToJSONSchema(schema, options?.config),

--- a/src/lib/adapters/zod.ts
+++ b/src/lib/adapters/zod.ts
@@ -1,8 +1,4 @@
-import {
-	type ZodErrorMap,
-	type ZodType,
-	type ZodTypeDef,
-} from 'zod';
+import { type ZodErrorMap, type ZodType, type ZodTypeDef } from 'zod';
 import type { JSONSchema7 } from 'json-schema';
 import {
 	type AdapterOptions,
@@ -28,10 +24,13 @@ export const zodToJSONSchema = (...params: Parameters<typeof zodToJson>) => {
 	return zodToJson(...params) as JSONSchema7;
 };
 
-
 // allows for any object schema
 // allows `undefined` in the input type to account for ZodDefault
-export type ZodObjectType = ZodType<Record<string, unknown>, ZodTypeDef, Record<string, unknown> | undefined>;
+export type ZodObjectType = ZodType<
+	Record<string, unknown>,
+	ZodTypeDef,
+	Record<string, unknown> | undefined
+>;
 export type ZodObjectTypes = ZodObjectType;
 
 // left in for compatibility reasons
@@ -43,11 +42,11 @@ async function validate<T extends ZodValidation>(
 	schema: T,
 	data: unknown,
 	errorMap: ZodErrorMap | undefined
-): Promise<ValidationResult<Infer<T, "zod">>> {
+): Promise<ValidationResult<Infer<T, 'zod'>>> {
 	const result = await schema.safeParseAsync(data, { errorMap });
 	if (result.success) {
 		return {
-			data: result.data as Infer<T, "zod">,
+			data: result.data as Infer<T, 'zod'>,
 			success: true
 		};
 	}
@@ -60,23 +59,23 @@ async function validate<T extends ZodValidation>(
 
 function _zod<T extends ZodValidation>(
 	schema: T,
-	options?: AdapterOptions<Infer<T, "zod">> & { errorMap?: ZodErrorMap; config?: Partial<Options> }
-): ValidationAdapter<Infer<T, "zod">, InferIn<T, "zod">> {
+	options?: AdapterOptions<Infer<T, 'zod'>> & { errorMap?: ZodErrorMap; config?: Partial<Options> }
+): ValidationAdapter<Infer<T, 'zod'>, InferIn<T, 'zod'>> {
 	return createAdapter({
-		superFormValidationLibrary: "zod",
-		async validate (data){
+		superFormValidationLibrary: 'zod',
+		async validate(data) {
 			// options?.defaults
-			return validate(schema, data, options?.errorMap)
+			return validate(schema, data, options?.errorMap);
 		},
 		jsonSchema: options?.jsonSchema ?? zodToJSONSchema(schema, options?.config),
-		defaults: options?.defaults,
+		defaults: options?.defaults
 	});
 }
 
 function _zodClient<T extends ZodValidation>(
 	schema: T,
 	options?: { errorMap?: ZodErrorMap }
-): ClientValidationAdapter<Infer<T, "zod">, InferIn<T, "zod">> {
+): ClientValidationAdapter<Infer<T, 'zod'>, InferIn<T, 'zod'>> {
 	return {
 		superFormValidationLibrary: 'zod',
 		validate: async (data) => validate(schema, data, options?.errorMap)


### PR DESCRIPTION
Zod creator here. This PR simplifies the Zod adapter and adds support for Zod 3.24. Should be a non-breaking change — the version range in peerDependencies is unchanged. I've verified that everything works with both 3.23.8 and 3.24.0.

Unfortunately some minor changes in 3.24 triggered an "Excessively deep and possibly infinite" TS error in this codebase, per #527. It's always a bit of a mystery as to why this error crops up. 

In this case, something about the "registry" approach used by `Infer` and `InferIn` was pretty inefficient, in that it takes the input and compares it against all supported schema types (Zod, Valibot, etc), then "filters out" the `never` values:

```ts
type Infer<TSchema extends Schema, Keys extends keyof Registry = keyof Registry> = UnknownIfNever<
	{
		[K in Keys]: IfDefined<InferOutput<Registry[K], TSchema>>;
	}[Keys]
>;
type InferIn<TSchema extends Schema, Keys extends keyof Registry = keyof Registry> = UnknownIfNever<
	{
		[K in Keys]: IfDefined<InferInput<Registry[K], TSchema>>;
	}[Keys]
>;
```

For the majority of adapters, you know upfront which schema library is expected, so I added a second (optional) generic to these utilities for the scenarios (as in `src/lib/adapters`) where you know in advance what schema type is expected. This should dramatically improve compiler performance in the adapters where it's implemented, and as an added bonus it resolves the "Excessively deep" error.

---


On top of this I simplified the Zod resolver to remove some unnecessary type complexity.