### PR TITLE
Opt out of runes mode in the SuperFormDebug component

### DIFF
--- a/src/lib/client/SuperDebug.svelte
+++ b/src/lib/client/SuperDebug.svelte
@@ -373,6 +373,8 @@
 	$: debugData = assertStore(data, raw) ? data : readable(data);
 </script>
 
+<svelte:options runes={false} />
+
 {#if !styleInit}
 	<style>
 		.super-debug--absolute {


### PR DESCRIPTION
## What did you build?

Force the SuperFormDebug component into legacy mode

Resolve issues outlined here https://github.com/ciscoheat/sveltekit-superforms/issues/306 & https://github.com/ciscoheat/sveltekit-superforms/issues/426

## Why did you add this?

Allows consumers to opt-in to runes on a project wide level by adding the following to their svelte.config.js. This will be the default behavior in Svelte 6 according to the [Svelte docs
](https://svelte.dev/docs/svelte/svelte-compiler#CompileOptions)
``` javascript

  compilerOptions: {
    runes: true,
  }
```