### PR TITLE
Adding typebox no compile adapter

### DIFF
--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -1,4 +1,5 @@
-export type { ValidationAdapter, ClientValidationAdapter, Infer, InferIn } from './adapters.js';
+export type { ValidationAdapter, ValidationResult, ClientValidationAdapter, Infer, InferIn } from './adapters.js';
+export { createAdapter } from "./adapters.js"
 
 export { arktype, arktypeClient } from './arktype.js';
 export { classvalidator, classvalidatorClient } from './classvalidator.js';

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -6,7 +6,7 @@ export { classvalidator, classvalidatorClient } from './classvalidator.js';
 export { effect, effectClient } from './effect.js';
 export { joi, joiClient } from './joi.js';
 export { superformClient } from './superform.js';
-export { typebox, typeboxClient } from './typebox.js';
+export { typebox, typeboxClient, typeboxNoCompile, typeboxClientNoCompile } from './typebox.js';
 export { valibot, valibotClient } from './valibot.js';
 export { yup, yupClient } from './yup.js';
 export {

--- a/src/lib/adapters/typebox.ts
+++ b/src/lib/adapters/typebox.ts
@@ -10,6 +10,7 @@ import type { TSchema } from '@sinclair/typebox';
 import type { TypeCheck } from '@sinclair/typebox/compiler';
 import { memoize } from '$lib/memoize.js';
 import { Value } from '@sinclair/typebox/value';
+import { FormatRegistry } from '@sinclair/typebox';
 
 // From https://github.com/sinclairzx81/typebox/tree/ca4d771b87ee1f8e953036c95a21da7150786d3e/example/formats
 const Email =
@@ -58,6 +59,10 @@ async function validateNoCompile<T extends TSchema>(
 	schema: T,
 	data: unknown
 ): Promise<ValidationResult<Infer<T, 'typebox'>>> {
+
+	if (!FormatRegistry.Has('email')) {
+		FormatRegistry.Set('email', (value) => Email.test(value));
+	}
 
 	const errors = [...(Value.Errors(schema, data) ?? [])];
 

--- a/src/lib/adapters/typebox.ts
+++ b/src/lib/adapters/typebox.ts
@@ -15,6 +15,26 @@ import { FormatRegistry } from '@sinclair/typebox';
 // From https://github.com/sinclairzx81/typebox/tree/ca4d771b87ee1f8e953036c95a21da7150786d3e/example/formats
 const Email =
 	/^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i;
+const DATE = /^(\d\d\d\d)-(\d\d)-(\d\d)$/;
+const DAYS = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+function IsLeapYear(year: number): boolean {
+	return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+function IsDate(str: string): boolean {
+	const matches: string[] | null = DATE.exec(str);
+	if (!matches) return false;
+	const year: number = +matches[1];
+	const month: number = +matches[2];
+	const day: number = +matches[3];
+	return (
+		month >= 1 &&
+		month <= 12 &&
+		day >= 1 &&
+		day <= (month === 2 && IsLeapYear(year) ? 29 : DAYS[month])
+	);
+}
 
 async function modules() {
 	const { TypeCompiler } = await import(/* webpackIgnore: true */ '@sinclair/typebox/compiler');
@@ -36,6 +56,9 @@ async function validate<T extends TSchema>(
 
 	if (!FormatRegistry.Has('email')) {
 		FormatRegistry.Set('email', (value) => Email.test(value));
+	}
+	if (!FormatRegistry.Has('date')) {
+		FormatRegistry.Set('date', (value) => IsDate(value));
 	}
 
 	const validator = compiled.get(schema);
@@ -62,6 +85,9 @@ async function validateNoCompile<T extends TSchema>(
 
 	if (!FormatRegistry.Has('email')) {
 		FormatRegistry.Set('email', (value) => Email.test(value));
+	}
+	if (!FormatRegistry.Has('date')) {
+		FormatRegistry.Set('date', (value) => IsDate(value));
 	}
 
 	const errors = [...(Value.Errors(schema, data) ?? [])];

--- a/src/routes/(v2)/v2/Navigation.svelte
+++ b/src/routes/(v2)/v2/Navigation.svelte
@@ -73,6 +73,7 @@
 		'effect',
 		'issue-500',
 		'typebox',
+    'typeboxNoCompile',
 		'transport',
 		'bigint',
 		'issue-455'

--- a/src/routes/(v2)/v2/typeboxNoCompile/+page.server.ts
+++ b/src/routes/(v2)/v2/typeboxNoCompile/+page.server.ts
@@ -1,0 +1,23 @@
+import { typeboxNoCompile } from '$lib/adapters/typebox.js';
+import { message, superValidate } from '$lib/server/index.js';
+import { schema } from './schema.js';
+import { fail } from '@sveltejs/kit';
+
+export const load = async () => {
+	const form = await superValidate(typeboxNoCompile(schema));
+	return { form };
+};
+
+export const actions = {
+	default: async ({ request }) => {
+		const formData = await request.formData();
+		console.log(formData);
+
+		const form = await superValidate(formData, typeboxNoCompile(schema));
+		console.log(form);
+
+		if (!form.valid) return fail(400, { form });
+
+		return message(form, 'Posted OK!');
+	}
+};

--- a/src/routes/(v2)/v2/typeboxNoCompile/+page.svelte
+++ b/src/routes/(v2)/v2/typeboxNoCompile/+page.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import { superForm } from '$lib/client/index.js';
+	import SuperDebug from '$lib/client/SuperDebug.svelte';
+	import { typeboxClientNoCompile } from '$lib/adapters/typebox.js';
+	import { schema } from './schema.js';
+
+	export let data;
+
+	const { form, errors, tainted, message, enhance } = superForm(data.form, {
+		taintedMessage: false,
+		validators: typeboxClientNoCompile(schema)
+		//dataType: 'json',
+	});
+</script>
+
+<SuperDebug data={{ $form, $errors, $tainted }} />
+
+{#if $message}<h4>{$message}</h4>{/if}
+
+<form method="POST" use:enhance>
+	<label>
+		Name: <input
+			name="name"
+			bind:value={$form.name}
+			aria-invalid={$errors.name ? 'true' : undefined}
+		/>
+		{#if $errors.name}<span class="invalid">{$errors.name}</span>{/if}
+	</label>
+	<label>
+		Email: <input
+			name="email"
+			bind:value={$form.email}
+			aria-invalid={$errors.email ? 'true' : undefined}
+		/>
+		{#if $errors.email}<span class="invalid">{$errors.email}</span>{/if}
+	</label>
+	<div>
+		<button>Submit</button>
+	</div>
+</form>
+
+<style lang="scss">
+	form {
+		margin: 2rem 0;
+
+		input {
+			background-color: #dedede;
+		}
+
+		.invalid {
+			color: crimson;
+		}
+	}
+</style>

--- a/src/routes/(v2)/v2/typeboxNoCompile/schema.ts
+++ b/src/routes/(v2)/v2/typeboxNoCompile/schema.ts
@@ -1,0 +1,6 @@
+import { Type } from '@sinclair/typebox';
+
+export const schema = Type.Object({
+	name: Type.String({ minLength: 2 }),
+	email: Type.String({ format: 'email' })
+});


### PR DESCRIPTION
Adding a typebox adapter which does does not use `TypeCompiler`

For issue in: https://github.com/ciscoheat/sveltekit-superforms/issues/541