### PR TITLE
fix: correctly handle allOf

### DIFF
--- a/src/lib/jsonSchema/schemaInfo.ts
+++ b/src/lib/jsonSchema/schemaInfo.ts
@@ -40,16 +40,6 @@ export function schemaInfo(
 ): SchemaInfo {
 	assertSchema(schema, path);
 
-	if (schema.allOf && schema.allOf.length) {
-		return {
-			...merge.withOptions(
-				{ allowUndefinedOverrides: false },
-				...schema.allOf.map((s) => schemaInfo(s, false, []))
-			),
-			schema
-		};
-	}
-
 	const types = schemaTypes(schema, path);
 
 	const array =
@@ -79,7 +69,7 @@ export function schemaInfo(
 
 	const union = unionInfo(schema)?.filter((u) => u.type !== 'null' && u.const !== null);
 
-	return {
+	const result: SchemaInfo = {
 		types: types.filter((s) => s !== 'null') as SchemaInfo['types'],
 		isOptional,
 		isNullable: types.includes('null'),
@@ -89,6 +79,19 @@ export function schemaInfo(
 		properties,
 		additionalProperties,
 		required: schema.required
+	};
+
+	if (!schema.allOf || !schema.allOf.length) {
+		return result;
+	}
+
+	return {
+		...merge.withOptions(
+			{ allowUndefinedOverrides: false },
+			result,
+			...schema.allOf.map((s) => schemaInfo(s, false, []))
+		),
+		schema
 	};
 }
 

--- a/src/tests/JSONSchema.test.ts
+++ b/src/tests/JSONSchema.test.ts
@@ -328,6 +328,19 @@ describe('Default values', () => {
 		const adapter = zod(userSchema);
 		expect(defaultValues(adapter.jsonSchema).gender).toBe('male');
 	});
+
+	it('should work with allOf', () => {
+		const userSchema = z.object({
+			username: z
+				.string()
+				.min(3)
+				.max(24)
+				.regex(/^[a-zA-Z](?!.*[_.-]{2})[a-zA-Z0-9_.-]*$/)
+				.regex(/^(?!guest).*/i)
+		});
+		const adapter = zod(userSchema);
+		expect(defaultValues(adapter.jsonSchema).username).toBe('');
+	});
 });
 
 describe('Unions (anyOf)', () => {


### PR DESCRIPTION
When a schema has `allOf`, the current `schemaInfo()` implementation merges the info from all the `allOf` branches. However, this excludes the schema itself. This means that in a schema like this one:

```js
{
    type: string
    allOf: [{ pattern: "abc" }]
}
```

the info will fail to figure out the type, as it only considers the inner schema.

This PR changes the info of a schema that contains `anyOf` from `merge(...allOfBranches.map(info))` to `merge(info(schema), ...allOfBranches.map(info))`, essentially adding the missing/lost information.

Fixes #560