### PR TITLE
Add the nav argument to taintedMessage fn

### DIFF
--- a/src/lib/client/superForm.ts
+++ b/src/lib/client/superForm.ts
@@ -95,7 +95,7 @@ export type FormOptions<
 	errorSelector: string;
 	selectErrorText: boolean;
 	stickyNavbar: string;
-	taintedMessage: string | boolean | null | (() => MaybePromise<boolean>);
+	taintedMessage: string | boolean | null | ((nav: BeforeNavigate) => MaybePromise<boolean>);
 	/**
 	 * Enable single page application (SPA) mode.
 	 * **The string and failStatus options are deprecated** and will be removed in the next major release.
@@ -1227,7 +1227,7 @@ export function superForm<
 			// - resolved with false => shouldRedirect = false
 			// - resolved with true => shouldRedirect = true
 			shouldRedirect = isTaintedFunction
-				? await taintedMessage()
+				? await taintedMessage(nav)
 				: window.confirm(message || Tainted.defaultMessage);
 		} catch {
 			shouldRedirect = false;


### PR DESCRIPTION
When using [shallow routing](https://svelte.dev/docs/kit/shallow-routing) sometimes you may wan't to use the `taintedMessage` function to prevent navigating away, but still allow the use of shallow navigation to display a modal on the same page.

By providing the nav argument to the tainted message function you can do something like
```ts
superForm(formData, {
    taintedMessage: (nav) => {
         if(nav.willUnload) {
            return dialog.confirm('Are you sure?')
         }
         return true;
    }
})
```

In this case, if you are navigating shallowly and the underlying page won't change and still will hold the for, you just allow the navigation, but if the page is going to unload and remove the form, you can display your dialog and await the outcome of the user interaction.