### PR TITLE
FormData | Allow ArkType's `string.uuid` not to be treated as a union

### DIFF
--- a/src/tests/superValidate.test.ts
+++ b/src/tests/superValidate.test.ts
@@ -397,6 +397,56 @@ describe('Arktype', () => {
 		expect(form.data).toEqual({ id: 123456789123456789n });
 	});
 
+	describe('with uuid', () => {
+		describe('with general uuid format', () => {
+			const schema = type({
+				id: 'string.uuid'
+			});
+
+			it('should handle the type', async () => {
+				const expectedUuid = '123e4567-e89b-12d3-a456-426614174000';
+				const adapter = arktype(schema);
+				const formData = new FormData();
+				formData.set('id', expectedUuid);
+
+				const form = await superValidate(formData, adapter);
+				expect(form.data).toEqual({ id: expectedUuid });
+			});
+
+			it('should preserve validation errors', async () => {
+				const adapter = arktype(schema);
+
+				const form = await superValidate({ id: 'invalid-uuid' }, adapter);
+				expect(form.valid).toBe(false);
+				expect(form.errors.id).toBeTruthy();
+			});
+		});
+
+		describe('with specific uuid format', () => {
+			const schema = type({
+				id: 'string.uuid.v7'
+			});
+
+			it('should handle the type', async () => {
+				const expectedUuid = '017f22e2-79b0-7cc5-98c4-dc0c0c07398f';
+				const adapter = arktype(schema);
+				const formData = new FormData();
+				formData.set('id', expectedUuid);
+
+				const form = await superValidate(formData, adapter);
+				expect(form.data).toEqual({ id: expectedUuid });
+			});
+
+			it('should preserve validation errors', async () => {
+				const adapter = arktype(schema);
+
+				const form = await superValidate({ id: '017f22e2-79b0-8cc5-98c4-dc0c0c07398f' }, adapter);
+				expect(form.valid).toBe(false);
+				expect(form.errors.id).toBeTruthy();
+			});
+		});
+	});
+
 	const schema = type({
 		name: 'string = "Unknown"',
 		email: 'string.email',


### PR DESCRIPTION
ArkType's `string.uuid` schema was incorrectly rejected during FormData parsing with the error:
> "Unions are only supported when the dataType option for superForm is set to 'json'"

This occurred because ArkType generates JSON schemas with `anyOf` containing multiple string constraints for UUID validation. The FormData parser was treating this same-type union as a problematic multi-type union and rejecting it.

This is the format of the `string.uuid` JSON schema:

```json
{
  "anyOf": [
    {
      "type": "string",
      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
    },
    {
      "type": "string", 
      "const": "00000000-0000-0000-0000-000000000000"
    },
    {
      "type": "string",
      "const": "ffffffff-ffff-ffff-ffff-ffffffffffff"
    }
  ]
}
```

In order to fix this we needed to enhance the FormData parsing logic to distinguish between:
- **Compatible unions**: Same-type constraints (like UUID variations) or nullable types
- **Incompatible unions**: True multi-type unions (string|number) that require JSON mode

In this PR we introduce a fix that enables ArkType's UUID schemas to work seamlessly with FormData while maintaining strict validation against incompatible union types. I

## Usage Examples

### ✅ Now Works (ArkType UUID)
```typescript
const schema = type({ id: 'string.uuid' });
const formData = new FormData();
formData.set('id', '123e4567-e89b-12d3-a456-426614174000');

const form = await superValidate(formData, arktype(schema));
// ✅ Success: form.data.id = '123e4567-e89b-12d3-a456-426614174000'
```

### ❌ Still Properly Rejected (Multi-Type Union)
```typescript
const schema = type({ value: 'string | number' });
const formData = new FormData();
formData.set('value', 'test');

const adapter = arktype(schema, { defaults: { value: 'default' } });
parseFormData(formData, adapter.jsonSchema);
// ❌ Throws: "Unions are only supported when dataType is 'json'"
```

### ✅ Works (Same-Type Literals)
```typescript
const schema = type({ status: '"active" | "inactive"' });
const formData = new FormData();
formData.set('status', 'active');

const result = parseFormData(formData, arktype(schema).jsonSchema);
// ✅ Success: result.data.status = 'active'
```