### PR TITLE
support npm zod 4.0.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
 		"svelte": "3.x || 4.x || >=5.0.0-next.51",
 		"valibot": "^1.0.0",
 		"yup": "^1.4.0",
-		"zod": "^3.25.0"
+    "zod": "^3.25.0 || ^4.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@exodus/schemasafe": {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
 		"svelte": "3.x || 4.x || >=5.0.0-next.51",
 		"valibot": "^1.0.0",
 		"yup": "^1.4.0",
-    "zod": "^3.25.0 || ^4.0.0"
+		"zod": "^3.25.0 || ^4.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@exodus/schemasafe": {

--- a/src/lib/adapters/typeSchema.ts
+++ b/src/lib/adapters/typeSchema.ts
@@ -14,7 +14,7 @@ import type {
 	InferOutput as Output
 } from 'valibot';
 import type { Schema as Schema$2, InferType } from 'yup';
-import type { ZodTypeAny, input, output } from 'zod';
+import type { ZodTypeAny, input, output } from 'zod/v3';
 import type { $ZodType, input as zod4Input, output as zod4Output } from 'zod/v4/core';
 import type { SchemaTypes, Infer as VineInfer } from '@vinejs/vine/types';
 import type { FromSchema, JSONSchema } from 'json-schema-to-ts';

--- a/src/lib/adapters/zod.ts
+++ b/src/lib/adapters/zod.ts
@@ -1,4 +1,4 @@
-import { type ZodErrorMap, type ZodType, type ZodTypeDef } from 'zod';
+import { type ZodErrorMap, type ZodType, type ZodTypeDef } from 'zod/v3';
 import type { JSONSchema7 } from 'json-schema';
 import {
 	type AdapterOptions,

--- a/src/routes/(v1)/+page.server.ts
+++ b/src/routes/(v1)/+page.server.ts
@@ -1,6 +1,6 @@
 import { superValidate } from '$lib/superValidate.js';
 import { zod } from '$lib/adapters/zod.js';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { error, fail } from '@sveltejs/kit';
 import { redirect } from 'sveltekit-flash-message/server';
 import { RateLimiter } from 'sveltekit-rate-limiter/server';

--- a/src/routes/(v1)/dates/+page.server.ts
+++ b/src/routes/(v1)/dates/+page.server.ts
@@ -2,7 +2,7 @@ import type { Actions, PageServerLoad } from './$types.js';
 import { superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
-import type { z } from 'zod';
+import type { z } from 'zod/v3';
 import { schema, schemaToStr } from './schema.js';
 
 export const load = (async ({ url }) => {

--- a/src/routes/(v1)/dates/schema.ts
+++ b/src/routes/(v1)/dates/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	str: z.string().datetime(),

--- a/src/routes/(v1)/empty-proxy/+page.server.ts
+++ b/src/routes/(v1)/empty-proxy/+page.server.ts
@@ -2,7 +2,7 @@ import { message, superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
 import { fail } from '@sveltejs/kit';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const schema = z.object({
 	string: z.string().min(2).nullable(),

--- a/src/routes/(v1)/files/+page.server.ts
+++ b/src/routes/(v1)/files/+page.server.ts
@@ -1,7 +1,7 @@
 import { message, superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { fail } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types.js';
 

--- a/src/routes/(v1)/multiple/+page.server.ts
+++ b/src/routes/(v1)/multiple/+page.server.ts
@@ -5,7 +5,7 @@ import { error, fail } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types.js';
 
 import { userSchema, users } from '../users.js';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 type Message = { message: string };
 

--- a/src/routes/(v1)/multiple2/+page.server.ts
+++ b/src/routes/(v1)/multiple2/+page.server.ts
@@ -2,7 +2,7 @@ import { message, superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
 import { fail } from '@sveltejs/kit';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import type { Actions } from './$types.js';
 
 const loginSchema = z.object({

--- a/src/routes/(v1)/multiple2/schemas.ts
+++ b/src/routes/(v1)/multiple2/schemas.ts
@@ -1,3 +1,3 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({});

--- a/src/routes/(v1)/nested-validation/+page.svelte
+++ b/src/routes/(v1)/nested-validation/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { SuperValidated } from '$lib/index.js';
 
-	import type { z } from 'zod';
+	import type { z } from 'zod/v3';
 	import type { PageData } from './$types.js';
 	import TagForm from './TagForm.svelte';
 	import type { schema } from './schema.js';

--- a/src/routes/(v1)/nested-validation/TagForm.svelte
+++ b/src/routes/(v1)/nested-validation/TagForm.svelte
@@ -8,7 +8,7 @@
 	import { onMount } from 'svelte';
 	import type { SuperValidated } from '$lib/index.js';
 
-	import type { z } from 'zod';
+	import type { z } from 'zod/v3';
 	import { zodClient } from '$lib/adapters/zod.js';
 	import { superformClient } from '$lib/adapters/superform.js';
 

--- a/src/routes/(v1)/nested-validation/schema.ts
+++ b/src/routes/(v1)/nested-validation/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z
 	.object({

--- a/src/routes/(v1)/nested/schema.ts
+++ b/src/routes/(v1)/nested/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z
 	.object({

--- a/src/routes/(v1)/properly-nested/Form.svelte
+++ b/src/routes/(v1)/properly-nested/Form.svelte
@@ -6,7 +6,7 @@
 	import TextField from './TextField.svelte';
 	import SuperDebug from '$lib/client/SuperDebug.svelte';
 	import { fieldProxy } from '$lib/client/index.js';
-	import type { z } from 'zod';
+	import type { z } from 'zod/v3';
 
 	export let data: SuperValidated<z.infer<Schema>>;
 

--- a/src/routes/(v1)/properly-nested/schemas.ts
+++ b/src/routes/(v1)/properly-nested/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v1)/proxies/+page.server.ts
+++ b/src/routes/(v1)/proxies/+page.server.ts
@@ -2,7 +2,7 @@ import type { Actions, PageServerLoad } from './$types.js';
 import { superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const schema = z.object({
 	bool: z.boolean()

--- a/src/routes/(v1)/record/schemas.ts
+++ b/src/routes/(v1)/record/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	data: z.record(z.number()).default({ first: 1, second: 2 })

--- a/src/routes/(v1)/reset/+page.svelte
+++ b/src/routes/(v1)/reset/+page.svelte
@@ -4,7 +4,7 @@
 	import SuperDebug from '$lib/client/SuperDebug.svelte';
 	import type { schema } from './schemas.js';
 	import { page } from '$app/stores';
-	import type { z } from 'zod';
+	import type { z } from 'zod/v3';
 
 	export let data: PageData;
 

--- a/src/routes/(v1)/reset/schemas.ts
+++ b/src/routes/(v1)/reset/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v1)/spa/without-zod/+page.svelte
+++ b/src/routes/(v1)/spa/without-zod/+page.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/stores';
 	import { superForm } from '$lib/client/index.js';
 	//import SuperDebug from '$lib/client/SuperDebug.svelte';
-	import { z } from 'zod';
+	import { z } from 'zod/v3';
 	import type { Schema } from './schema.js';
 	import { superformClient } from '$lib/adapters/superform.js';
 

--- a/src/routes/(v1)/spa/without-zod/schema.ts
+++ b/src/routes/(v1)/spa/without-zod/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z
 	.object({

--- a/src/routes/(v1)/spa/zod-page-ts/schema.ts
+++ b/src/routes/(v1)/spa/zod-page-ts/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z
 	.object({

--- a/src/routes/(v1)/spa/zod/schema.ts
+++ b/src/routes/(v1)/spa/zod/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z
 	.object({

--- a/src/routes/(v1)/super-debug/+page.server.ts
+++ b/src/routes/(v1)/super-debug/+page.server.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 

--- a/src/routes/(v1)/super-debug/extensive-usage-cases/+page.server.ts
+++ b/src/routes/(v1)/super-debug/extensive-usage-cases/+page.server.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 

--- a/src/routes/(v1)/superforms-plain/schema.ts
+++ b/src/routes/(v1)/superforms-plain/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v1)/tainted/multiple-tainted/schemas.ts
+++ b/src/routes/(v1)/tainted/multiple-tainted/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string(),

--- a/src/routes/(v1)/tainted/programmatically/+page.server.ts
+++ b/src/routes/(v1)/tainted/programmatically/+page.server.ts
@@ -2,7 +2,7 @@ import { superValidate, message } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
 import { fail } from '@sveltejs/kit';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const schema = z
 	.object({

--- a/src/routes/(v1)/tainted/schema.ts
+++ b/src/routes/(v1)/tainted/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z
 	.object({

--- a/src/routes/(v1)/test/+page.server.ts
+++ b/src/routes/(v1)/test/+page.server.ts
@@ -1,7 +1,7 @@
 import { setError, superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { fail, redirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types.js';
 

--- a/src/routes/(v1)/test/login/+server.ts
+++ b/src/routes/(v1)/test/login/+server.ts
@@ -1,7 +1,7 @@
 import { actionResult, superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import type { RequestHandler } from './$types.js';
 
 const loginSchema = z.object({

--- a/src/routes/(v1)/tests/_empty/schema.ts
+++ b/src/routes/(v1)/tests/_empty/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v1)/tests/array-component/schema.ts
+++ b/src/routes/(v1)/tests/array-component/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	sub: z.object({

--- a/src/routes/(v1)/tests/array-error-tainted/schema.ts
+++ b/src/routes/(v1)/tests/array-error-tainted/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v1)/tests/array-level-error-2/+page.server.ts
+++ b/src/routes/(v1)/tests/array-level-error-2/+page.server.ts
@@ -2,7 +2,7 @@ import { superValidate, message, setError } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
 import { fail } from '@sveltejs/kit';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import type { Actions, PageServerLoad } from './$types.js';
 

--- a/src/routes/(v1)/tests/bound-component/schemas.ts
+++ b/src/routes/(v1)/tests/bound-component/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z

--- a/src/routes/(v1)/tests/checkbox-validation/schemas.ts
+++ b/src/routes/(v1)/tests/checkbox-validation/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	isAccredited: z.literal(true)

--- a/src/routes/(v1)/tests/custom-validity/schema.ts
+++ b/src/routes/(v1)/tests/custom-validity/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1),

--- a/src/routes/(v1)/tests/datetime-local/schema.ts
+++ b/src/routes/(v1)/tests/datetime-local/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	emptyUndef: z.number().optional(),

--- a/src/routes/(v1)/tests/default-object/schema.ts
+++ b/src/routes/(v1)/tests/default-object/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const questionSchema = z.object({
 	text: z.string().min(2, 'Ask a longer question.'),

--- a/src/routes/(v1)/tests/delayed-validation/schema.ts
+++ b/src/routes/(v1)/tests/delayed-validation/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const basicSchema = z
 	.object({

--- a/src/routes/(v1)/tests/delayed-validation/username/+server.ts
+++ b/src/routes/(v1)/tests/delayed-validation/username/+server.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import type { RequestHandler } from './$types.js';
 import { superValidate } from '$lib/superValidate.js';
 import { zod } from '$lib/adapters/zod.js';

--- a/src/routes/(v1)/tests/events/schema.ts
+++ b/src/routes/(v1)/tests/events/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v1)/tests/flash-onerror/schema.ts
+++ b/src/routes/(v1)/tests/flash-onerror/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v1)/tests/issue-142/+page.server.ts
+++ b/src/routes/(v1)/tests/issue-142/+page.server.ts
@@ -4,7 +4,7 @@ import type { SuperValidated } from '$lib/index.js';
 
 import { fail } from '@sveltejs/kit';
 import { schema } from './schema.js';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const load = async () => {
 	const form = await superValidate(zod(schema));

--- a/src/routes/(v1)/tests/issue-142/schema.ts
+++ b/src/routes/(v1)/tests/issue-142/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z
 	.object({

--- a/src/routes/(v1)/tests/issue-159/schemas.ts
+++ b/src/routes/(v1)/tests/issue-159/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const overallValidation = (data: { name: string; email: string }): boolean => {
 	const result = !!data.name || !!data.email;

--- a/src/routes/(v1)/tests/issue-161/schema.ts
+++ b/src/routes/(v1)/tests/issue-161/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z
 	.object({

--- a/src/routes/(v1)/tests/issue-164-2/+page.server.ts
+++ b/src/routes/(v1)/tests/issue-164-2/+page.server.ts
@@ -2,7 +2,7 @@ import { superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
 import { error, fail } from '@sveltejs/kit';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const barSchema = z.object({
 	name: z.string(),

--- a/src/routes/(v1)/tests/issue-164-2/schemas.ts
+++ b/src/routes/(v1)/tests/issue-164-2/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v1)/tests/issue-164-3/[viewOrEdit]/+page.server.ts
+++ b/src/routes/(v1)/tests/issue-164-3/[viewOrEdit]/+page.server.ts
@@ -1,7 +1,7 @@
 import { superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const schema = z.object({
 	name: z.string().min(1, 'Cannot be empty')

--- a/src/routes/(v1)/tests/issue-164-4/+page.server.ts
+++ b/src/routes/(v1)/tests/issue-164-4/+page.server.ts
@@ -2,7 +2,7 @@ import { superValidate, message } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
 import { fail } from '@sveltejs/kit';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import type { Actions, PageServerLoad } from './$types.js';
 

--- a/src/routes/(v1)/tests/issue-164/+page.server.ts
+++ b/src/routes/(v1)/tests/issue-164/+page.server.ts
@@ -1,7 +1,7 @@
 import { superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const schema = z.object({
 	name: z.string(),

--- a/src/routes/(v1)/tests/issue-164/schemas.ts
+++ b/src/routes/(v1)/tests/issue-164/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v1)/tests/issue-176/+page.svelte
+++ b/src/routes/(v1)/tests/issue-176/+page.svelte
@@ -3,7 +3,7 @@
 	import { zod } from '$lib/adapters/zod.js';
 
 	import { page } from '$app/stores';
-	import { z } from 'zod';
+	import { z } from 'zod/v3';
 
 	const loginSchema = z.object({
 		email: z.string().email(),

--- a/src/routes/(v1)/tests/issue-194/schema.ts
+++ b/src/routes/(v1)/tests/issue-194/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	things: z.set(z.number()).default(new Set([2, 3]))

--- a/src/routes/(v1)/tests/issue-195/schema.ts
+++ b/src/routes/(v1)/tests/issue-195/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	emaillist: z.boolean().optional().default(true)

--- a/src/routes/(v1)/tests/issue-196/+page.svelte
+++ b/src/routes/(v1)/tests/issue-196/+page.svelte
@@ -2,7 +2,7 @@
 	import { superForm, defaults } from '$lib/client/index.js';
 	import { zod } from '$lib/adapters/zod.js';
 
-	import { z } from 'zod';
+	import { z } from 'zod/v3';
 
 	const childSchema = z.object({
 		option: z.enum(['', 'one', 'two', 'three'])

--- a/src/routes/(v1)/tests/issue-208/+page.server.ts
+++ b/src/routes/(v1)/tests/issue-208/+page.server.ts
@@ -3,7 +3,7 @@ import { message, superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
 import { fail } from '@sveltejs/kit';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { UserType, NumberType } from './UserType.js';
 
 const schema = z.object({

--- a/src/routes/(v1)/tests/issue-208/schema.ts
+++ b/src/routes/(v1)/tests/issue-208/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v1)/tests/issue-227/+page.server.ts
+++ b/src/routes/(v1)/tests/issue-227/+page.server.ts
@@ -1,7 +1,7 @@
 import { superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const schema = z.object({
 	name: z.string().default('Hello world!'),

--- a/src/routes/(v1)/tests/issue-230/+layout.svelte
+++ b/src/routes/(v1)/tests/issue-230/+layout.svelte
@@ -4,7 +4,7 @@
 	import { zod } from '$lib/adapters/zod.js';
 
 	import SuperDebug from '$lib/client/SuperDebug.svelte';
-	import { z } from 'zod';
+	import { z } from 'zod/v3';
 
 	const schema = z.object({
 		name: z.string().min(1),

--- a/src/routes/(v1)/tests/issue-230/+page.server.ts
+++ b/src/routes/(v1)/tests/issue-230/+page.server.ts
@@ -2,7 +2,7 @@ import { superValidate, message } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
 import { fail } from '@sveltejs/kit';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const schema = z.object({
 	name: z.string().min(1),

--- a/src/routes/(v1)/tests/issue-233/schema.ts
+++ b/src/routes/(v1)/tests/issue-233/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const age = z
 	.any()

--- a/src/routes/(v1)/tests/issue-235/schema.ts
+++ b/src/routes/(v1)/tests/issue-235/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const exampleSchema = z.object({
 	radioGroup: z.boolean().default(false),

--- a/src/routes/(v1)/tests/issue-260/+page.server.ts
+++ b/src/routes/(v1)/tests/issue-260/+page.server.ts
@@ -4,7 +4,7 @@ import { zod } from '$lib/adapters/zod.js';
 
 import type { Actions, PageServerLoad } from './$types.js';
 import { schema, type Message } from './utils.js';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 ///// Load function /////
 

--- a/src/routes/(v1)/tests/issue-260/utils.ts
+++ b/src/routes/(v1)/tests/issue-260/utils.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v1)/tests/issue-266/schema.ts
+++ b/src/routes/(v1)/tests/issue-266/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	business_id: z.string(),

--- a/src/routes/(v1)/tests/issue-270/+page.server.ts
+++ b/src/routes/(v1)/tests/issue-270/+page.server.ts
@@ -2,7 +2,7 @@ import { superValidate, message } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
 import { fail } from '@sveltejs/kit';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import type { Actions, PageServerLoad } from './$types.js';
 

--- a/src/routes/(v1)/tests/issue-270/+page.svelte
+++ b/src/routes/(v1)/tests/issue-270/+page.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/stores';
 	import { zod } from '$lib/adapters/zod.js';
 	import { superForm } from '$lib/client/index.js';
-	import { z } from 'zod';
+	import { z } from 'zod/v3';
 
 	export let data;
 

--- a/src/routes/(v1)/tests/issue-298/+page.svelte
+++ b/src/routes/(v1)/tests/issue-298/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { z } from 'zod';
+	import { z } from 'zod/v3';
 	import { superForm as _superForm } from '$lib/client/index.js';
 	import { defaults } from '$lib/client/index.js';
 	import { zod } from '$lib/adapters/zod.js';

--- a/src/routes/(v1)/tests/missing-data-validate/schema.ts
+++ b/src/routes/(v1)/tests/missing-data-validate/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	age: z.number().min(30),

--- a/src/routes/(v1)/tests/multiselect-2/+page.server.ts
+++ b/src/routes/(v1)/tests/multiselect-2/+page.server.ts
@@ -4,7 +4,7 @@ import { zod } from '$lib/adapters/zod.js';
 
 import { schema } from './schema.js';
 import { error } from '@sveltejs/kit';
-import type { z } from 'zod';
+import type { z } from 'zod/v3';
 
 const groups = [
 	{

--- a/src/routes/(v1)/tests/multiselect-2/+page.svelte
+++ b/src/routes/(v1)/tests/multiselect-2/+page.svelte
@@ -3,7 +3,7 @@
 	import type { PageData } from './$types.js';
 	import SuperDebug from '$lib/client/SuperDebug.svelte';
 	import { schema } from './schema.js';
-	import type { z } from 'zod';
+	import type { z } from 'zod/v3';
 	import { zod } from '$lib/adapters/zod.js';
 
 	export let data: PageData;

--- a/src/routes/(v1)/tests/multiselect-2/schema.ts
+++ b/src/routes/(v1)/tests/multiselect-2/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	email: z.string().email().nullable(),

--- a/src/routes/(v1)/tests/multiselect/+page.server.ts
+++ b/src/routes/(v1)/tests/multiselect/+page.server.ts
@@ -5,7 +5,7 @@ import { zod } from '$lib/adapters/zod.js';
 import type { Actions, PageServerLoad } from './$types.js';
 
 import { formSchema } from './schemas.js';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const load: PageServerLoad = async () => {
 	const form = await superValidate<z.infer<typeof formSchema>, { message: string }>(

--- a/src/routes/(v1)/tests/multiselect/schemas.ts
+++ b/src/routes/(v1)/tests/multiselect/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const optionsSchema = z
 	.enum(['option_1', 'option_2', 'option_3', 'option_4'])

--- a/src/routes/(v1)/tests/no-enhance/+page.server.ts
+++ b/src/routes/(v1)/tests/no-enhance/+page.server.ts
@@ -2,7 +2,7 @@ import { superValidate, message } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
 import { fail } from '@sveltejs/kit';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import type { Actions, PageServerLoad } from './$types.js';
 

--- a/src/routes/(v1)/tests/no-js-dropdown/+page.server.ts
+++ b/src/routes/(v1)/tests/no-js-dropdown/+page.server.ts
@@ -2,7 +2,7 @@ import { message, superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
 import { fail } from '@sveltejs/kit';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 import type { Actions, PageServerLoad } from './$types.js';
 

--- a/src/routes/(v1)/tests/non-enhance/reset/schemas.ts
+++ b/src/routes/(v1)/tests/non-enhance/reset/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2)

--- a/src/routes/(v1)/tests/proxy-in-proxy/schema.ts
+++ b/src/routes/(v1)/tests/proxy-in-proxy/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	date: z.date()

--- a/src/routes/(v1)/tests/rate-limiter/schema.ts
+++ b/src/routes/(v1)/tests/rate-limiter/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1),

--- a/src/routes/(v1)/tests/redirect-same-route/schema.ts
+++ b/src/routes/(v1)/tests/redirect-same-route/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1).default('Test')

--- a/src/routes/(v1)/tests/redirect-submitting/[uuid]/+page.server.ts
+++ b/src/routes/(v1)/tests/redirect-submitting/[uuid]/+page.server.ts
@@ -1,5 +1,5 @@
 import { fail, redirect } from '@sveltejs/kit';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { v4 } from 'uuid';
 import { zod } from '$lib/adapters/zod.js';
 import { superValidate } from '$lib/superValidate.js';

--- a/src/routes/(v1)/tests/refine-in-generics/+page.server.ts
+++ b/src/routes/(v1)/tests/refine-in-generics/+page.server.ts
@@ -3,7 +3,7 @@ import { superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
 import { RegisterSchema } from './schemas.js';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const load = (async (event) => {
 	const form = await superValidate(event, zod(RegisterSchema));

--- a/src/routes/(v1)/tests/refine-in-generics/schemas.ts
+++ b/src/routes/(v1)/tests/refine-in-generics/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const RegisterSchema = z
 	.object({

--- a/src/routes/(v1)/tests/refine-validation-2/schema.ts
+++ b/src/routes/(v1)/tests/refine-validation-2/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 export const userSchema = z
 	.object({
 		salutationId: z.number().positive(),

--- a/src/routes/(v1)/tests/refine-validation/schema.ts
+++ b/src/routes/(v1)/tests/refine-validation/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z
 	.object({

--- a/src/routes/(v1)/tests/reset-component-2/schema.ts
+++ b/src/routes/(v1)/tests/reset-component-2/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const registerSchema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v1)/tests/reset-component/Form.svelte
+++ b/src/routes/(v1)/tests/reset-component/Form.svelte
@@ -2,7 +2,7 @@
 	import { superForm, defaults } from '$lib/client/index.js';
 	import { zod } from '$lib/adapters/zod.js';
 
-	import { z } from 'zod';
+	import { z } from 'zod/v3';
 	import SuperDebug from '$lib/client/SuperDebug.svelte';
 	import { page } from '$app/stores';
 

--- a/src/routes/(v1)/tests/reset-component/schema.ts
+++ b/src/routes/(v1)/tests/reset-component/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v1)/tests/resetting-form-problem/schemas.ts
+++ b/src/routes/(v1)/tests/resetting-form-problem/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1, {

--- a/src/routes/(v1)/tests/rex/schema.ts
+++ b/src/routes/(v1)/tests/rex/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const basicSchema = z.object({
 	name: z.string().min(4).default('Hello world!'),

--- a/src/routes/(v1)/tests/scroll-into-view/schema.ts
+++ b/src/routes/(v1)/tests/scroll-into-view/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2)

--- a/src/routes/(v1)/tests/spa-schema-transform/schema.ts
+++ b/src/routes/(v1)/tests/spa-schema-transform/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1).trim(),

--- a/src/routes/(v1)/tests/spa-submit/+page.ts
+++ b/src/routes/(v1)/tests/spa-submit/+page.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { superValidate } from '$lib/client/index.js';
 import { zod } from '$lib/adapters/zod.js';
 

--- a/src/routes/(v1)/tests/spa-values-disappearing/+page.ts
+++ b/src/routes/(v1)/tests/spa-values-disappearing/+page.ts
@@ -1,7 +1,7 @@
 import { superValidate } from '$lib/client/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const _schema = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v1)/tests/sten/+page.server.ts
+++ b/src/routes/(v1)/tests/sten/+page.server.ts
@@ -2,7 +2,7 @@ import { fail } from '@sveltejs/kit';
 import { superValidate } from '$lib/server/index.js';
 import { zod } from '$lib/adapters/zod.js';
 
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const postSchema = z.object({
 	questions: z

--- a/src/routes/(v1)/tests/sten/+page.svelte
+++ b/src/routes/(v1)/tests/sten/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { z } from 'zod';
+	import { z } from 'zod/v3';
 	import { page } from '$app/stores';
 	import { superForm } from '$lib/client/index.js';
 	import { zod } from '$lib/adapters/zod.js';

--- a/src/routes/(v1)/tests/strict-mode/schema.ts
+++ b/src/routes/(v1)/tests/strict-mode/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v1)/tests/superform-c/schema.ts
+++ b/src/routes/(v1)/tests/superform-c/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z
 	.object({

--- a/src/routes/(v1)/tests/tainted-array/+page.svelte
+++ b/src/routes/(v1)/tests/tainted-array/+page.svelte
@@ -2,7 +2,7 @@
 	import { superForm, defaults, arrayProxy } from '$lib/client/index.js';
 	import { zod as adapter } from '$lib/adapters/zod.js';
 
-	import * as zod from 'zod';
+	import * as zod from 'zod/v3';
 	import SuperDebug from '$lib/client/SuperDebug.svelte';
 
 	const schema = zod.object({

--- a/src/routes/(v1)/tests/tainted-proxy/schema.ts
+++ b/src/routes/(v1)/tests/tainted-proxy/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	user: z.object({

--- a/src/routes/(v1)/tests/unions/schemas.ts
+++ b/src/routes/(v1)/tests/unions/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	references: z

--- a/src/routes/(v1)/timers/schema.ts
+++ b/src/routes/(v1)/timers/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1).default('Name')

--- a/src/routes/(v1)/url/+page.server.ts
+++ b/src/routes/(v1)/url/+page.server.ts
@@ -3,7 +3,7 @@ import { zod } from '$lib/adapters/zod.js';
 
 import { fail } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types.js';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const schema = z.object({
 	id: z.number().int().positive().default(NaN)

--- a/src/routes/(v1)/users.ts
+++ b/src/routes/(v1)/users.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 // See https://zod.dev/?id=primitives for schema syntax
 export const userSchema = z.object({

--- a/src/routes/(v2)/v2/_empty/schema.ts
+++ b/src/routes/(v2)/v2/_empty/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/allow-files/schema.ts
+++ b/src/routes/(v2)/v2/allow-files/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	avatar: z

--- a/src/routes/(v2)/v2/app-error/schema.ts
+++ b/src/routes/(v2)/v2/app-error/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const userSchema = z.object({
 	name: z.string(),

--- a/src/routes/(v2)/v2/array-errors2/+page.svelte
+++ b/src/routes/(v2)/v2/array-errors2/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { z } from 'zod';
+	import { z } from 'zod/v3';
 	import { defaults, superForm } from '$lib/index.js';
 	import { zod } from '$lib//adapters/zod.js';
 

--- a/src/routes/(v2)/v2/array-proxy/schema.ts
+++ b/src/routes/(v2)/v2/array-proxy/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	tags: z.array(z.string().min(1)).nonempty()

--- a/src/routes/(v2)/v2/bigint/schema.ts
+++ b/src/routes/(v2)/v2/bigint/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	number: z.bigint().min(BigInt(1000000), 'A BIG number please!')

--- a/src/routes/(v2)/v2/boolean-same-union/schema.ts
+++ b/src/routes/(v2)/v2/boolean-same-union/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	active: z.boolean().optional(),

--- a/src/routes/(v2)/v2/capture-files/schema.ts
+++ b/src/routes/(v2)/v2/capture-files/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	image: z.instanceof(File, { message: 'Please upload a file.' }).nullable(),

--- a/src/routes/(v2)/v2/catchall/schema.ts
+++ b/src/routes/(v2)/v2/catchall/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z
 	.object({

--- a/src/routes/(v2)/v2/component-regen/+page.svelte
+++ b/src/routes/(v2)/v2/component-regen/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import z from 'zod';
+	import z from 'zod/v3';
 	import Form from './Form.svelte';
 	import TextField from './TextField.svelte';
 	import SuperDebug from '$lib/index.js';

--- a/src/routes/(v2)/v2/component-regen/Form.svelte
+++ b/src/routes/(v2)/v2/component-regen/Form.svelte
@@ -5,7 +5,7 @@
 <script lang="ts" generics="Schema extends ZodSchema">
 	import { defaults, superForm } from '$lib/index.js';
 	import { zod } from '$lib/adapters/zod.js';
-	import { z, ZodSchema } from 'zod';
+	import { z, ZodSchema } from 'zod/v3';
 
 	type SchemaObject = z.infer<Schema>;
 	export let schema: Schema;

--- a/src/routes/(v2)/v2/component-sf-type/schema.ts
+++ b/src/routes/(v2)/v2/component-sf-type/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const three = z.object({
 	a: z.string(),

--- a/src/routes/(v2)/v2/components/schema.ts
+++ b/src/routes/(v2)/v2/components/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const registerSchema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/custom-tainted-dialog/schema.ts
+++ b/src/routes/(v2)/v2/custom-tainted-dialog/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v2)/v2/custom-validity/schema.ts
+++ b/src/routes/(v2)/v2/custom-validity/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1),

--- a/src/routes/(v2)/v2/customrequest-validate/schema.ts
+++ b/src/routes/(v2)/v2/customrequest-validate/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/customrequest/schema.ts
+++ b/src/routes/(v2)/v2/customrequest/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	track: z.instanceof(File, { message: 'Please upload a file.' })

--- a/src/routes/(v2)/v2/debounce-username/schema.ts
+++ b/src/routes/(v2)/v2/debounce-username/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	username: z

--- a/src/routes/(v2)/v2/defaults-fail/schema.ts
+++ b/src/routes/(v2)/v2/defaults-fail/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1),

--- a/src/routes/(v2)/v2/discord/array-remove/+page.server.ts
+++ b/src/routes/(v2)/v2/discord/array-remove/+page.server.ts
@@ -5,7 +5,7 @@ import { schema } from './schema.js';
 import type { Actions, PageServerLoad } from './$types.js';
 import { zod } from '$lib/adapters/zod.js';
 import { userSchema, users } from './users.js';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const db = users();
 const union = z.union([schema, userSchema]);

--- a/src/routes/(v2)/v2/discord/array-remove/FieldComponent.svelte
+++ b/src/routes/(v2)/v2/discord/array-remove/FieldComponent.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { z } from 'zod';
+	import { z } from 'zod/v3';
 	import type { userSchema } from './users.js';
 	import { arrayProxy } from '$lib/client/proxies.js';
 	export let form;

--- a/src/routes/(v2)/v2/discord/array-remove/schema.ts
+++ b/src/routes/(v2)/v2/discord/array-remove/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const emailSchema = z.object({
 	type: z.string().optional(),

--- a/src/routes/(v2)/v2/discord/array-remove/users.ts
+++ b/src/routes/(v2)/v2/discord/array-remove/users.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 // See https://zod.dev/?id=primitives for schema syntax
 const emailSchema = z.object({

--- a/src/routes/(v2)/v2/discriminated-union/schema.ts
+++ b/src/routes/(v2)/v2/discriminated-union/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.discriminatedUnion('type', [
 	z.object({

--- a/src/routes/(v2)/v2/dynamic-validators/+page.svelte
+++ b/src/routes/(v2)/v2/dynamic-validators/+page.svelte
@@ -3,7 +3,7 @@
 	import SuperDebug from '$lib/client/SuperDebug.svelte';
 	import { zod } from '$lib/adapters/zod.js';
 	import { schema } from './schema.js';
-	import { z } from 'zod';
+	import { z } from 'zod/v3';
 
 	export let data;
 

--- a/src/routes/(v2)/v2/dynamic-validators/schema.ts
+++ b/src/routes/(v2)/v2/dynamic-validators/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/empty-enum/schema.ts
+++ b/src/routes/(v2)/v2/empty-enum/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const fishes = ['trout', 'tuna', 'shark'] as const;
 

--- a/src/routes/(v2)/v2/file-component/schema.ts
+++ b/src/routes/(v2)/v2/file-component/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1),

--- a/src/routes/(v2)/v2/files-proxy/schema.ts
+++ b/src/routes/(v2)/v2/files-proxy/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	images: z

--- a/src/routes/(v2)/v2/form-result-type/schema.ts
+++ b/src/routes/(v2)/v2/form-result-type/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	dir: z

--- a/src/routes/(v2)/v2/formsnap/schema.ts
+++ b/src/routes/(v2)/v2/formsnap/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 /*
 type T = {

--- a/src/routes/(v2)/v2/goto-onupdated/schema.ts
+++ b/src/routes/(v2)/v2/goto-onupdated/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/id-incorrect/schema.ts
+++ b/src/routes/(v2)/v2/id-incorrect/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/index-errors/schema.ts
+++ b/src/routes/(v2)/v2/index-errors/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const itemSchema = z.object({
 	name: z.string()

--- a/src/routes/(v2)/v2/issue-309-unions/form.svelte
+++ b/src/routes/(v2)/v2/issue-309-unions/form.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { z } from 'zod';
+	import type { z } from 'zod/v3';
 	import type { unionizedSchema } from './user-schema.js';
 	import type { SuperForm } from '$lib/index.js';
 	import TextInput from './text-input.svelte';

--- a/src/routes/(v2)/v2/issue-309-unions/user-schema.ts
+++ b/src/routes/(v2)/v2/issue-309-unions/user-schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const createUserSchema = z.object({
 	email: z.string(),

--- a/src/routes/(v2)/v2/issue-332-arrays/schema.ts
+++ b/src/routes/(v2)/v2/issue-332-arrays/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().default('Hello world!'),

--- a/src/routes/(v2)/v2/issue-337-checkboxes/schema.ts
+++ b/src/routes/(v2)/v2/issue-337-checkboxes/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	accept: z.boolean(),

--- a/src/routes/(v2)/v2/issue-345/schema.ts
+++ b/src/routes/(v2)/v2/issue-345/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	checkbox: z.boolean().optional()

--- a/src/routes/(v2)/v2/issue-356/schema.ts
+++ b/src/routes/(v2)/v2/issue-356/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	id: z.string(),

--- a/src/routes/(v2)/v2/issue-358/schema.ts
+++ b/src/routes/(v2)/v2/issue-358/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1),

--- a/src/routes/(v2)/v2/issue-360/schema.ts
+++ b/src/routes/(v2)/v2/issue-360/schema.ts
@@ -1,3 +1,3 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({});

--- a/src/routes/(v2)/v2/issue-368/+page.svelte
+++ b/src/routes/(v2)/v2/issue-368/+page.svelte
@@ -3,7 +3,7 @@
 	import { superForm } from '$lib/index.js';
 	import SuperDebug from '$lib/index.js';
 	import { zod } from '$lib/adapters/zod.js';
-	import { ZodIssueCode } from 'zod';
+	import { ZodIssueCode } from 'zod/v3';
 	import { schema } from './schema.js';
 
 	export let data;

--- a/src/routes/(v2)/v2/issue-368/schema.ts
+++ b/src/routes/(v2)/v2/issue-368/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(5),

--- a/src/routes/(v2)/v2/issue-374/schema.ts
+++ b/src/routes/(v2)/v2/issue-374/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const otherSchema1 = z.string();
 const otherSchema2 = z.object({

--- a/src/routes/(v2)/v2/issue-398/schema.ts
+++ b/src/routes/(v2)/v2/issue-398/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	file: z.instanceof(File).refine((f) => f.size < 100_000, 'Max 100 kB upload size.')

--- a/src/routes/(v2)/v2/issue-455/schema.ts
+++ b/src/routes/(v2)/v2/issue-455/schema.ts
@@ -1,5 +1,5 @@
 import i18next from 'i18next';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 // @ts-expect-error Need to use .mjs, explanation: https://stackoverflow.com/a/77108389/70894
 import { zodI18nMap } from 'zod-i18n-map/dist/index.mjs';
 import translation from 'zod-i18n-map/locales/es/zod.json?raw';

--- a/src/routes/(v2)/v2/issue-464/schema.ts
+++ b/src/routes/(v2)/v2/issue-464/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	testArray: z.number().array(),

--- a/src/routes/(v2)/v2/issue-466/schema.ts
+++ b/src/routes/(v2)/v2/issue-466/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1),

--- a/src/routes/(v2)/v2/issue-467/shared.ts
+++ b/src/routes/(v2)/v2/issue-467/shared.ts
@@ -1,4 +1,4 @@
-import { object, string, z } from 'zod';
+import { object, string, z } from 'zod/v3';
 
 export const Schema1 = object({
 	value1: string().min(1)

--- a/src/routes/(v2)/v2/issue-470/schema.ts
+++ b/src/routes/(v2)/v2/issue-470/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	value: z.number().nullable()

--- a/src/routes/(v2)/v2/issue-484/schemas.ts
+++ b/src/routes/(v2)/v2/issue-484/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import type { JSONSchema } from '$lib/index.js';
 
 export const loginZodSchema = z.object({

--- a/src/routes/(v2)/v2/issue-485/schema.ts
+++ b/src/routes/(v2)/v2/issue-485/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/issue-500/schema.ts
+++ b/src/routes/(v2)/v2/issue-500/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const inviteUserToGroupSchema = z.object({
 	username: z.string().min(2)

--- a/src/routes/(v2)/v2/issue-583/schema.ts
+++ b/src/routes/(v2)/v2/issue-583/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const dueDateValueSchema = z
 	.date()

--- a/src/routes/(v2)/v2/issue-588/schema.ts
+++ b/src/routes/(v2)/v2/issue-588/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/letters/schema.ts
+++ b/src/routes/(v2)/v2/letters/schema.ts
@@ -1,5 +1,5 @@
 import { zod } from '$lib/adapters/zod.js';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const generateSchema = (category: string) =>
 	zod(z.object(Object.fromEntries([...category].map((q) => [q, z.string().min(1)]))));

--- a/src/routes/(v2)/v2/mixed-forms/schema.ts
+++ b/src/routes/(v2)/v2/mixed-forms/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/modify-reset/schema.ts
+++ b/src/routes/(v2)/v2/modify-reset/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/multiple-files/schema.ts
+++ b/src/routes/(v2)/v2/multiple-files/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	images: z

--- a/src/routes/(v2)/v2/multistep-client/schema.ts
+++ b/src/routes/(v2)/v2/multistep-client/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schemaStep1 = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v2)/v2/multistep-server/schema.ts
+++ b/src/routes/(v2)/v2/multistep-server/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schemaStep1 = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v2)/v2/nested-files/schema.ts
+++ b/src/routes/(v2)/v2/nested-files/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	image: z

--- a/src/routes/(v2)/v2/nested-generic/schema.ts
+++ b/src/routes/(v2)/v2/nested-generic/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().default('Hello world!'),

--- a/src/routes/(v2)/v2/nested-traverse/+page.server.ts
+++ b/src/routes/(v2)/v2/nested-traverse/+page.server.ts
@@ -1,5 +1,5 @@
 import { nerveForm } from './schema.js';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { message, superValidate } from '$lib/index.js';
 import { zod } from '$lib/adapters/zod.js';
 import type { Actions } from '@sveltejs/kit';

--- a/src/routes/(v2)/v2/nested-traverse/schema.ts
+++ b/src/routes/(v2)/v2/nested-traverse/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const deficitForm = z.object({
 	grade: z.number().min(0).max(100).nullable().default(null),

--- a/src/routes/(v2)/v2/on-change-event/schema.ts
+++ b/src/routes/(v2)/v2/on-change-event/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1),

--- a/src/routes/(v2)/v2/onchange-target/schema.ts
+++ b/src/routes/(v2)/v2/onchange-target/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v2)/v2/oninput-errors/schema.ts
+++ b/src/routes/(v2)/v2/oninput-errors/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/posted/schema.ts
+++ b/src/routes/(v2)/v2/posted/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1),

--- a/src/routes/(v2)/v2/redirect-login/login/schema.ts
+++ b/src/routes/(v2)/v2/redirect-login/login/schema.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import z from 'zod/v3';
 
 export const login_schema = z.object({
 	email: z.string().email(),

--- a/src/routes/(v2)/v2/redirect/schema.ts
+++ b/src/routes/(v2)/v2/redirect/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/reset-errors/schema.ts
+++ b/src/routes/(v2)/v2/reset-errors/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/return-multiple-forms/schema.ts
+++ b/src/routes/(v2)/v2/return-multiple-forms/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	email: z.string().email()

--- a/src/routes/(v2)/v2/simple-tainted/schema.ts
+++ b/src/routes/(v2)/v2/simple-tainted/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 // Define at the top-level so it stays in memory and the adapter can be cached
 export const schema = z.object({

--- a/src/routes/(v2)/v2/snapshot-proxy/schema.ts
+++ b/src/routes/(v2)/v2/snapshot-proxy/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/step-form/+page.svelte
+++ b/src/routes/(v2)/v2/step-form/+page.svelte
@@ -3,7 +3,7 @@
 	import SuperDebug from '$lib/client/SuperDebug.svelte';
 	import { zod, zodClient } from '$lib/adapters/zod.js';
 	import { step1, step2, step3 } from './schema.js';
-	import { z } from 'zod';
+	import { z } from 'zod/v3';
 
 	let { data } = $props();
 

--- a/src/routes/(v2)/v2/step-form/schema.ts
+++ b/src/routes/(v2)/v2/step-form/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/submit-enter/schema.ts
+++ b/src/routes/(v2)/v2/submit-enter/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1),

--- a/src/routes/(v2)/v2/submit-json/schema.ts
+++ b/src/routes/(v2)/v2/submit-json/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/submit-prog/schema.ts
+++ b/src/routes/(v2)/v2/submit-prog/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2)

--- a/src/routes/(v2)/v2/syncflash/schema.ts
+++ b/src/routes/(v2)/v2/syncflash/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2).default('OK')

--- a/src/routes/(v2)/v2/tainted-array/schema.ts
+++ b/src/routes/(v2)/v2/tainted-array/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	details: z

--- a/src/routes/(v2)/v2/tainted-component/schema.ts
+++ b/src/routes/(v2)/v2/tainted-component/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2),

--- a/src/routes/(v2)/v2/tainted-history/schema.ts
+++ b/src/routes/(v2)/v2/tainted-history/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1),

--- a/src/routes/(v2)/v2/tainted-null-random/schema.ts
+++ b/src/routes/(v2)/v2/tainted-null-random/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	foo: z

--- a/src/routes/(v2)/v2/timeproxy/schema.ts
+++ b/src/routes/(v2)/v2/timeproxy/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	time: z.date(),

--- a/src/routes/(v2)/v2/transport/schema.ts
+++ b/src/routes/(v2)/v2/transport/schema.ts
@@ -1,5 +1,5 @@
 import { Decimal } from 'decimal.js';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { RecordId } from '../../../RecordId.js';
 
 export const schema = z.object({

--- a/src/routes/(v2)/v2/trim-fields/schema.ts
+++ b/src/routes/(v2)/v2/trim-fields/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(2).trim(),

--- a/src/routes/(v2)/v2/union-component/schemas.ts
+++ b/src/routes/(v2)/v2/union-component/schemas.ts
@@ -1,5 +1,5 @@
 import type { Infer } from '$lib/index.js';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const eventSchema = z.object({
 	name: z.string(),

--- a/src/routes/(v2)/v2/unions/schema.ts
+++ b/src/routes/(v2)/v2/unions/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schemaUnion = z.union([
 	z.object({

--- a/src/routes/(v2)/v2/unknown-in-schema/schema.ts
+++ b/src/routes/(v2)/v2/unknown-in-schema/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string(),

--- a/src/routes/(v2)/v2/validate-update/schema.ts
+++ b/src/routes/(v2)/v2/validate-update/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v2)/v2/validate/schema.ts
+++ b/src/routes/(v2)/v2/validate/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1)

--- a/src/routes/(v2)/v2/validators-clear/schema.ts
+++ b/src/routes/(v2)/v2/validators-clear/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(5)

--- a/src/routes/(v2)/v2/validity-objects/schema.ts
+++ b/src/routes/(v2)/v2/validity-objects/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	priceRules: z

--- a/src/routes/(v2)/v2/zod-discriminated/schema.ts
+++ b/src/routes/(v2)/v2/zod-discriminated/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 export const schema = z.object({
 	name: z.string().min(1),

--- a/src/tests/JSONSchema.test.ts
+++ b/src/tests/JSONSchema.test.ts
@@ -4,7 +4,7 @@ import { schemaInfo } from '$lib/jsonSchema/schemaInfo.js';
 import type { FromSchema } from 'json-schema-to-ts';
 import { defaultValues, defaultTypes } from '$lib/jsonSchema/schemaDefaults.js';
 import { schemaShape, shapeFromObject } from '$lib/jsonSchema/schemaShape.js';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { zod, zodToJSONSchema } from '$lib/adapters/zod.js';
 import { schemaHash } from '$lib/jsonSchema/schemaHash.js';
 import { constraints } from '$lib/jsonSchema/constraints.js';

--- a/src/tests/data.ts
+++ b/src/tests/data.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { z as z4 } from 'zod/v4';
 
 import { zodToJSONSchema } from '$lib/adapters/zod.js';

--- a/src/tests/errors.test.ts
+++ b/src/tests/errors.test.ts
@@ -2,7 +2,7 @@ import { zod } from '$lib/adapters/zod.js';
 import { flattenErrors, mergeDefaults, replaceInvalidDefaults } from '$lib/errors.js';
 import type { ValidationErrors } from '$lib/superValidate.js';
 import { describe, it, expect } from 'vitest';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 describe('Flattening errors', () => {
 	it('should work with array-level errors', () => {

--- a/src/tests/formData.test.ts
+++ b/src/tests/formData.test.ts
@@ -6,7 +6,7 @@ import { SchemaError } from '$lib/index.js';
 import { type } from 'arktype';
 import * as v from 'valibot';
 import { assert, describe, expect, it } from 'vitest';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 enum Foo {
 	A = 2,

--- a/src/tests/legacy/compare.test.ts
+++ b/src/tests/legacy/compare.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, expect, expectTypeOf, test } from 'vitest';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { pathExists } from '$lib/traversal.js';
 import { get, writable } from 'svelte/store';
 import { superValidate } from '$lib/superValidate.js';

--- a/src/tests/legacy/errors.test.ts
+++ b/src/tests/legacy/errors.test.ts
@@ -2,7 +2,7 @@ import { zod, zodToJSONSchema } from '$lib/adapters/zod.js';
 import { schemaShape } from '$lib/jsonSchema/schemaShape.js';
 import { setError, superValidate } from '$lib/superValidate.js';
 import { expect, test, describe, assert } from 'vitest';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 describe('Errors', async () => {
 	const schema = z.object({

--- a/src/tests/legacy/index.test.ts
+++ b/src/tests/legacy/index.test.ts
@@ -1,6 +1,6 @@
 import { setError, setMessage, superValidate } from '$lib/superValidate.js';
 import { assert, expect, test, describe } from 'vitest';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { dataTypeForm } from '../data.js';
 import { zod } from '$lib/adapters/zod.js';
 import { zodToJSONSchema } from '$lib/adapters/zod.js';

--- a/src/tests/legacy/paths.test-d.ts
+++ b/src/tests/legacy/paths.test-d.ts
@@ -11,7 +11,7 @@ import type {
 } from '$lib/stringPath.js';
 import { writable } from 'svelte/store';
 import { test } from 'vitest';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 type Obj = {
 	name: string;

--- a/src/tests/legacy/proxies.test.ts
+++ b/src/tests/legacy/proxies.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import { get, writable } from 'svelte/store';
 import { superValidate } from '$lib/superValidate.js';
 import { booleanProxy, dateProxy, fieldProxy, intProxy, numberProxy } from '$lib/client/index.js';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { zod } from '$lib/adapters/zod.js';
 
 describe('Value proxies', () => {

--- a/src/tests/legacy/strict.test.ts
+++ b/src/tests/legacy/strict.test.ts
@@ -1,7 +1,7 @@
 import { zod } from '$lib/adapters/zod.js';
 import { superValidate } from '$lib/superValidate.js';
 import { expect, test, describe } from 'vitest';
-import { z, type AnyZodObject } from 'zod';
+import { z, type AnyZodObject } from 'zod/v3';
 
 type ModeTest = {
 	name: string;

--- a/src/tests/superForm.test.ts
+++ b/src/tests/superForm.test.ts
@@ -4,7 +4,7 @@ import { superValidate, type SuperValidated } from '$lib/superValidate.js';
 import { get } from 'svelte/store';
 import { merge } from 'ts-deepmerge';
 import { describe, it, expect, beforeEach, test } from 'vitest';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import { SuperFormError } from '$lib/errors.js';
 
 const schema = z.object({

--- a/src/tests/superValidate.test.ts
+++ b/src/tests/superValidate.test.ts
@@ -18,7 +18,7 @@ import { Foo, bigZod4Schema, bigZodSchema } from './data.js';
 ///// Adapters //////////////////////////////////////////////////////
 
 import { zod, zodToJSONSchema } from '$lib/adapters/zod.js';
-import { z, type ZodErrorMap } from 'zod';
+import { z, type ZodErrorMap } from 'zod/v3';
 
 import { zod as zod4, zodToJSONSchema as zod4ToJSONSchema } from '$lib/adapters/zod4.js';
 import { z as z4 } from 'zod/v4';

--- a/src/tests/zodUnion.test.ts
+++ b/src/tests/zodUnion.test.ts
@@ -3,7 +3,7 @@ import { zod } from '$lib/adapters/zod.js';
 import { superValidate } from '$lib/superValidate.js';
 import { stringify } from 'devalue';
 import { assert, describe, expect, test } from 'vitest';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 async function validate<T extends Record<string, unknown>>(
 	data: T,


### PR DESCRIPTION
zod 4 was formally released on npm https://github.com/colinhacks/zod/releases/tag/v4.0.1

`import from 'zod'` now defaults to `v4`, so specifying `import from 'zod/v3'` should allow for using newer versions. Should be no changes otherwise.