### PR TITLE
fix: bump devalue

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
 		"zod-to-json-schema": "^3.24.5"
 	},
 	"dependencies": {
-		"devalue": "^5.1.1",
+		"devalue": "^5.3.2",
 		"memoize-weak": "^1.0.2",
 		"ts-deepmerge": "^7.0.3"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       devalue:
-        specifier: ^5.1.1
-        version: 5.1.1
+        specifier: ^5.3.2
+        version: 5.3.2
       memoize-weak:
         specifier: ^1.0.2
         version: 1.0.2
@@ -999,8 +999,8 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
-  devalue@5.1.1:
-    resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
+  devalue@5.3.2:
+    resolution: {integrity: sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==}
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
@@ -2187,7 +2187,7 @@ snapshots:
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
-      devalue: 5.1.1
+      devalue: 5.3.2
       esm-env: 1.2.2
       kleur: 4.1.5
       magic-string: 0.30.17
@@ -2546,7 +2546,7 @@ snapshots:
   detect-libc@1.0.3:
     optional: true
 
-  devalue@5.1.1: {}
+  devalue@5.3.2: {}
 
   dlv@1.1.3:
     optional: true


### PR DESCRIPTION
[CVE-2025-57820](https://github.com/sveltejs/devalue/security/advisories/GHSA-vj54-72f3-p5jv) was recently reported on `devalue`. This PR updates to the latest version