### PR TITLE
fix: replace `@finom/zod-to-json-schema` with `zod-v3-to-json-schema`

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
 	},
 	"optionalDependencies": {
 		"@exodus/schemasafe": "^1.3.0",
-		"@finom/zod-to-json-schema": "^3.24.11",
+		"zod-v3-to-json-schema": "^4.0.0",
 		"@gcornut/valibot-json-schema": "^0.42.0",
 		"@typeschema/class-validator": "^0.3.0",
 		"@vinejs/vine": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,9 +130,6 @@ importers:
       '@exodus/schemasafe':
         specifier: ^1.3.0
         version: 1.3.0
-      '@finom/zod-to-json-schema':
-        specifier: ^3.24.11
-        version: 3.24.11(zod@4.1.11)
       '@gcornut/valibot-json-schema':
         specifier: ^0.42.0
         version: 0.42.0(esbuild@0.25.10)(typescript@5.9.3)
@@ -172,6 +169,9 @@ importers:
       zod:
         specifier: ^4.1.11
         version: 4.1.11
+      zod-v3-to-json-schema:
+        specifier: ^4.0.0
+        version: 4.0.0(zod@4.1.11)
 
 packages:
 
@@ -394,11 +394,6 @@ packages:
 
   '@exodus/schemasafe@1.3.0':
     resolution: {integrity: sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==}
-
-  '@finom/zod-to-json-schema@3.24.11':
-    resolution: {integrity: sha512-fL656yBPiWebtfGItvtXLWrFNGlF1NcDFS0WdMQXMs9LluVg0CfT5E2oXYp0pidl0vVG53XkW55ysijNkU5/hA==}
-    peerDependencies:
-      zod: ^4.0.14
 
   '@gcornut/valibot-json-schema@0.42.0':
     resolution: {integrity: sha512-4Et4AN6wmqeA0PfU5Clkv/IS27wiefsWf6TemAZrb75uzkClYEFavim7SboeKwbll9Nbsn2Iv0LT/HS5H7orZg==}
@@ -1811,6 +1806,11 @@ packages:
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
+  zod-v3-to-json-schema@4.0.0:
+    resolution: {integrity: sha512-KixLrhX/uPmRFnDgsZrzrk4x5SSJA+PmaE5adbfID9+3KPJcdxqRobaHU397EfWBqfQircrjKqvEqZ/mW5QH6w==}
+    peerDependencies:
+      zod: ^3.25 || ^4.0.14
+
   zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
@@ -1959,11 +1959,6 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/schemasafe@1.3.0':
-    optional: true
-
-  '@finom/zod-to-json-schema@3.24.11(zod@4.1.11)':
-    dependencies:
-      zod: 4.1.11
     optional: true
 
   '@gcornut/valibot-json-schema@0.42.0(esbuild@0.25.10)(typescript@5.9.3)':
@@ -3346,6 +3341,11 @@ snapshots:
     optional: true
 
   zimmerframe@1.1.4: {}
+
+  zod-v3-to-json-schema@4.0.0(zod@4.1.11):
+    dependencies:
+      zod: 4.1.11
+    optional: true
 
   zod@4.1.11:
     optional: true

--- a/src/lib/adapters/zod.ts
+++ b/src/lib/adapters/zod.ts
@@ -9,7 +9,7 @@ import {
 	type ValidationResult,
 	type ClientValidationAdapter
 } from './adapters.js';
-import { zodToJsonSchema as zodToJson, type Options } from '@finom/zod-to-json-schema';
+import { zodToJsonSchema as zodToJson, type Options } from 'zod-v3-to-json-schema';
 import { memoize } from '$lib/memoize.js';
 
 const defaultOptions: Partial<Options> = {


### PR DESCRIPTION
`@finom/zod-to-json-schema` is deprecated, see this comment: https://github.com/StefanTerdell/zod-to-json-schema/issues/178#issuecomment-3533122539 

Deprecation warning:
<img width="594" height="101" alt="image" src="https://github.com/user-attachments/assets/ee23efca-8356-424f-8e74-34b2273eeab2" />
