### PR TITLE
enhancement: improve error messages and add runtime detection for Zod v3/v4 (#1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Improved error message for "No shape could be created for schema" to suggest using `zod4` adapter when applicable. [#594](https://github.com/ciscoheat/sveltekit-superforms/issues/594)
+- Added runtime detection warning when Zod v4 schema is passed to Zod v3 adapter, helping users identify adapter version mismatch. [#594](https://github.com/ciscoheat/sveltekit-superforms/issues/594)
 - Valibot adapter now handles transformation actions (`trim`, `transform`, etc.) properly by using `typeMode: 'input'` and `errorMode: 'ignore'` as defaults. This prevents errors when schemas contain transformations. Users can override these settings by passing `typeMode` and `errorMode` options to the adapter. [#668](https://github.com/ciscoheat/sveltekit-superforms/pull/668)
 
 ## [2.29.1] - 2025-12-16

--- a/src/lib/adapters/zod.ts
+++ b/src/lib/adapters/zod.ts
@@ -59,6 +59,14 @@ function _zod<T extends ZodValidation>(
 	schema: T,
 	options?: AdapterOptions<Infer<T, 'zod'>> & { errorMap?: ZodErrorMap; config?: Partial<Options> }
 ): ValidationAdapter<Infer<T, 'zod'>, InferIn<T, 'zod'>> {
+	// Detect Zod v4 schema passed to v3 adapter
+	if ('_zod' in schema && typeof (schema as Record<string, unknown>)._zod === 'object') {
+		console.warn(
+			'[superforms] Zod v4 schema detected but using Zod v3 adapter. ' +
+				'Import { zod4 } from "sveltekit-superforms/adapters" instead of { zod } for Zod v4 support.'
+		);
+	}
+
 	return createAdapter({
 		superFormValidationLibrary: 'zod',
 		validate: async (data) => {

--- a/src/lib/jsonSchema/schemaShape.ts
+++ b/src/lib/jsonSchema/schemaShape.ts
@@ -16,7 +16,13 @@ export type SchemaShape = {
 export function schemaShape(schema: JSONSchema, path: string[] = []): SchemaShape {
 	const output = _schemaShape(schema, path);
 
-	if (!output) throw new SchemaError('No shape could be created for schema.', path);
+	if (!output) {
+		throw new SchemaError(
+			'No shape could be created for schema. ' +
+				'If using Zod v4, import { zod4 } from "sveltekit-superforms/adapters" instead of { zod }.',
+			path
+		);
+	}
 	return output;
 }
 

--- a/src/tests/zod-version-detection.test.ts
+++ b/src/tests/zod-version-detection.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { z as z3 } from 'zod/v3';
+import { z as z4 } from 'zod/v4';
+import { zod } from '$lib/adapters/zod.js';
+import { zod as zod4 } from '$lib/adapters/zod4.js';
+
+describe('Zod version mismatch detection', () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		warnSpy.mockRestore();
+	});
+
+	it('should warn when Zod v4 schema is passed to v3 adapter', () => {
+		const schema = z4.object({ name: z4.string() });
+
+		// This should trigger a warning before throwing an error
+		// The error is expected since v4 schema can't be properly processed by v3 adapter
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			zod(schema as any);
+		} catch {
+			// Expected to throw - the important thing is the warning was emitted first
+		}
+
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Zod v4 schema detected'));
+	});
+
+	it('should not warn when Zod v3 schema is passed to v3 adapter', () => {
+		const schema = z3.object({ name: z3.string() });
+
+		zod(schema);
+
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it('should not warn when Zod v4 schema is passed to v4 adapter', () => {
+		const schema = z4.object({ name: z4.string() });
+
+		zod4(schema);
+
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Hi there!  

This is my stab at improving the migration flow from zod 3 --> zod 4, I like other users frequently encounter the cryptic error "No shape could be created for schema" when mistakenly using the Zod v3 adapter (`zod`) with Zod v4 schemas.    

This appears to be a common source of confusion (see #594, #630, #649), and I for one usually forget the `zod4` revisions needed when upgrading projects to the new structure. 

Enhancements:
- **Revise error message with hint** - Add hint to "No shape could be created" error suggesting the `zod4` adapter
-  **Runtime detection** - Add `console.warn()` in the `zod` adapter when a Zod v4 schema structure is detected
- Added a test


Some questions:
1. Is the `[superforms]` prefix desired for warnings, or should a different format be used?
2. Should the detection also be added to `zodToJSONSchema` function for earlier detection?
3. Any preference on test file naming convention?

Closes #673 
Closes #594

### Add Runtime Detection to Zod v3 Adapter

**File:** `src/lib/adapters/zod.ts:58-70`
- `console.warn` is allowed by ESLint config
- Warning is emitted at adapter creation time (early detection)
- Message includes actionable fix
- Prefix `[superforms]` helps identify source

---

### Test for Runtime Detection

**File:** `src/tests/zod-version-detection.test.ts` (new file)


### To test:

```bash
cd /Users/jsullivan2/git/sveltekit-superforms
pnpm install
pnpm test
pnpm lint                    # Check code style
pnpm check                   # TypeScript checks
```

### Manual Testing

1. Create a test project with Zod v4
2. Import `{ zod }` (v3 adapter) instead of `{ zod4 }`
3. Verify warning is emitted in console
4. Verify error message includes helpful hint