### PR TITLE
fix: update devalue to v5.6.2 to resolve CVE-2026-22774

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
 		"zod-v3-to-json-schema": "^4.0.0"
 	},
 	"dependencies": {
-		"devalue": "^5.6.1",
+		"devalue": "^5.6.2",
 		"memoize-weak": "^1.0.2",
 		"ts-deepmerge": "^7.0.3"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       devalue:
-        specifier: ^5.6.1
-        version: 5.6.1
+        specifier: ^5.6.2
+        version: 5.6.2
       memoize-weak:
         specifier: ^1.0.2
         version: 1.0.2
@@ -126,9 +126,6 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.10.4)(sass@1.96.0)
-      zod-v3-to-json-schema:
-        specifier: ^4.0.0
-        version: 4.0.0(zod@4.1.13)
     optionalDependencies:
       '@exodus/schemasafe':
         specifier: ^1.3.0
@@ -172,6 +169,9 @@ importers:
       zod:
         specifier: ^4.1.13
         version: 4.1.13
+      zod-v3-to-json-schema:
+        specifier: ^4.0.0
+        version: 4.0.0(zod@4.1.13)
 
 packages:
 
@@ -988,8 +988,8 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
-  devalue@5.6.1:
-    resolution: {integrity: sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==}
+  devalue@5.6.2:
+    resolution: {integrity: sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==}
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
@@ -2103,7 +2103,7 @@ snapshots:
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
-      devalue: 5.6.1
+      devalue: 5.6.2
       esm-env: 1.2.2
       kleur: 4.1.5
       magic-string: 0.30.21
@@ -2471,7 +2471,7 @@ snapshots:
   detect-libc@1.0.3:
     optional: true
 
-  devalue@5.6.1: {}
+  devalue@5.6.2: {}
 
   dlv@1.1.3:
     optional: true
@@ -3020,7 +3020,7 @@ snapshots:
       aria-query: 5.3.2
       axobject-query: 4.1.0
       clsx: 2.1.1
-      devalue: 5.6.1
+      devalue: 5.6.2
       esm-env: 1.2.2
       esrap: 2.2.1
       is-reference: 3.0.3
@@ -3228,5 +3228,7 @@ snapshots:
   zod-v3-to-json-schema@4.0.0(zod@4.1.13):
     dependencies:
       zod: 4.1.13
+    optional: true
 
-  zod@4.1.13: {}
+  zod@4.1.13:
+    optional: true


### PR DESCRIPTION
Updates devalue dependency from v5.6.1 to v5.6.2 to address a denial of service vulnerability (CVE-2026-22774) that could cause excessive CPU and memory consumption when parsing malicious input. Closes #676 